### PR TITLE
Fix SAT solver heuristic counts

### DIFF
--- a/SAT.cpp
+++ b/SAT.cpp
@@ -201,7 +201,15 @@ public:
     void addClause(const std::vector<int>& literals) {
         clauses.emplace_back(literals);
         for (int lit : literals) {
-            variables.insert(abs(lit));
+            int var = std::abs(lit);
+            variables.insert(var);
+
+            // Track literal occurrences for heuristics
+            if (lit > 0) {
+                var_info[var].pos_occurrences++;
+            } else {
+                var_info[var].neg_occurrences++;
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- track positive and negative literal occurrences when adding clauses

## Testing
- `g++ -std=c++17 SAT.cpp -o SAT`
- `g++ -std=c++17 Hamming32bit1Gb.cpp -o Hamming32`
- `g++ -std=c++17 Hamming64bit128Gb.cpp -o Hamming64`
- `g++ -std=c++17 BCHvsHamming.cpp -o BCHvsHamming`


------
https://chatgpt.com/codex/tasks/task_e_685fab446790832eb7fdd14d02ecf350