### PR TITLE
Fix comment for overall parity position

### DIFF
--- a/Hamming64bit128Gb.cpp
+++ b/Hamming64bit128Gb.cpp
@@ -94,7 +94,7 @@ public:
     
     // Check if position is overall parity position
     bool isOverallParityPosition(int pos) {
-        return pos == TOTAL_BITS;  // Position 39
+        return pos == TOTAL_BITS;  // Position 72
     }
     
     // Get data bit positions (non-parity, non-overall-parity positions)


### PR DESCRIPTION
## Summary
- fix incorrect comment in `isOverallParityPosition`

## Testing
- `g++ -std=c++11 -o Hamming64bit128Gb Hamming64bit128Gb.cpp`
- `./Hamming64bit128Gb`

------
https://chatgpt.com/codex/tasks/task_e_685fae330e34832e8cc33103346775e0