### PR TITLE
Add energy estimation script

### DIFF
--- a/docs/EnergyModel.md
+++ b/docs/EnergyModel.md
@@ -1,0 +1,41 @@
+# Energy Model
+
+This module provides a tiny energy estimation for each read operation in the
+simulators. It multiplies the number of XOR and AND gate evaluations by
+constant energy costs.
+
+## Constants
+
+- `ENERGY_PER_XOR` – energy in joules used by a single XOR gate. The default
+  value is `2e-12` J.
+- `ENERGY_PER_AND` – energy in joules used by a single AND gate. The default
+  value is `1e-12` J.
+
+## Running the script
+
+1. From the repository root, run the module with the number of parity bits and
+   optionally the detected error count:
+
+   ```bash
+   python3 energy_model.py <parity_bits> [detected_errors]
+   ```
+
+   Example:
+
+   ```bash
+   python3 energy_model.py 8 1
+   ```
+
+   The command above estimates the energy to process eight parity bits when one
+   error was detected.
+
+2. The script prints a single line:
+
+   ```
+   Estimated energy per read: <value> J
+   ```
+
+   `<value>` is the estimated energy in joules, formatted in scientific notation.
+
+This simple calculation helps gauge the energy impact of different error control
+coding schemes during reads without running the full simulators.

--- a/energy_model.py
+++ b/energy_model.py
@@ -1,0 +1,47 @@
+"""Simple energy model for error correction operations.
+
+This module provides a function to estimate the energy consumed when reading a
+code word protected by parity bits. The estimate uses basic constants for the
+energy cost of XOR and AND gates.
+"""
+
+ENERGY_PER_XOR = 2e-12  # Joules
+"""Energy consumed by a single XOR gate operation."""
+
+ENERGY_PER_AND = 1e-12  # Joules
+"""Energy consumed by a single AND gate operation."""
+
+
+def estimate_energy(parity_bits: int, detected_errors: int) -> float:
+    """Estimate the energy required to read a word.
+
+    Parameters
+    ----------
+    parity_bits : int
+        Number of parity bits evaluated using XOR gates.
+    detected_errors : int
+        Number of detected error bits which trigger AND gate checks.
+
+    Returns
+    -------
+    float
+        Estimated energy in joules for the read operation.
+    """
+    if parity_bits < 0 or detected_errors < 0:
+        raise ValueError("Counts must be non-negative")
+    return parity_bits * ENERGY_PER_XOR + detected_errors * ENERGY_PER_AND
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Estimate energy per read")
+    parser.add_argument("parity_bits", type=int, help="Number of parity bits")
+    parser.add_argument(
+        "detected_errors", type=int, nargs="?", default=0,
+        help="Number of detected error bits (default: 0)"
+    )
+    args = parser.parse_args()
+
+    energy = estimate_energy(args.parity_bits, args.detected_errors)
+    print(f"Estimated energy per read: {energy:.3e} J")


### PR DESCRIPTION
## Summary
- implement `energy_model.py` for estimating energy per read
- document usage in `docs/EnergyModel.md`

## Testing
- `python3 -m py_compile energy_model.py`
- `python3 energy_model.py 8 1`

------
https://chatgpt.com/codex/tasks/task_e_6861793b7ee4832e8ab87832598f728a