### PR TITLE
Add million word dataset stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,22 @@ ECC for SRAM, studying the impact of ECC architectures on sustainablity
 
 The program prints a detailed report and writes `comparison_results.csv`
 to the repository root containing a summary table of each test case.
+
+## Running the 64-bit memory simulator
+
+1. Compile the simulator:
+
+   ```bash
+   g++ -std=c++11 Hamming64bit128Gb.cpp -o Hamming64bit128Gb
+   ```
+
+2. Execute the binary:
+
+   ```bash
+   ./Hamming64bit128Gb
+   ```
+
+The built-in test suite now includes a `Million Word Dataset` stress test
+which touches one million addresses using the simulator's write and read
+operations. After completion, the program prints a short summary of how many
+errors were corrected or detected during the test.


### PR DESCRIPTION
## Summary
- extend AdvancedTestSuite with `testMillionWordDataset`
- run this new test in the simulator
- document how to run the 64-bit simulator and the new test in README

## Testing
- `g++ -std=c++11 Hamming64bit128Gb.cpp -o Hamming64bit128Gb`
- `./Hamming64bit128Gb > /tmp/output.log && tail -n 20 /tmp/output.log`

------
https://chatgpt.com/codex/tasks/task_e_686179da7718832eb43a17adf803c559