### PR TITLE
Add gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build outputs
+*.out
+*.o
+comparison_results.csv
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini


### PR DESCRIPTION
## Summary
- add repo-wide `.gitignore` file
- ignore build outputs and OS-specific files

## Testing
- `g++ -std=c++11 BCHvsHamming.cpp -o BCHvsHamming.out`
- `g++ -std=c++11 -c BCHvsHamming.cpp -o BCHvsHamming.o`
- `./BCHvsHamming.out >/dev/null`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686183ed3928832e9058eb54b32d6e34