### PR TITLE
Introduce parity-check matrix helper

### DIFF
--- a/BitVector.hpp
+++ b/BitVector.hpp
@@ -1,0 +1,28 @@
+#ifndef BITVECTOR_HPP
+#define BITVECTOR_HPP
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+
+struct BitVector {
+    std::array<uint64_t,2> words{};
+
+    BitVector() : words{0,0} {}
+    BitVector(uint64_t low, uint64_t high=0) : words{low,high} {}
+
+    bool get(std::size_t pos) const {
+        if (pos >= 128) return false;
+        return (words[pos/64] >> (pos % 64)) & 1ULL;
+    }
+
+    void set(std::size_t pos, bool value) {
+        if (pos >= 128) return;
+        if (value)
+            words[pos/64] |= (1ULL << (pos % 64));
+        else
+            words[pos/64] &= ~(1ULL << (pos % 64));
+    }
+};
+
+#endif // BITVECTOR_HPP

--- a/Hamming32bit1Gb.cpp
+++ b/Hamming32bit1Gb.cpp
@@ -10,6 +10,7 @@
 #include <set>
 #include <unordered_map>
 #include <fstream>
+#include "ParityCheckMatrix.hpp"
 
 class HammingCodeSECDED {
 public:
@@ -136,23 +137,32 @@ public:
         result.error_position = 0;
         result.data_corrected = false;
         
-        // Calculate Hamming syndrome
-        for (int i = 0; i < PARITY_BITS; i++) {
-            int parity_bit = parity_positions[i];
-            int parity = 0;
-            
-            // Check all positions that this parity bit covers (excluding overall parity)
-            for (int pos = 1; pos <= TOTAL_BITS - 1; pos++) {
-                if ((pos & parity_bit) != 0) {
-                    if (received.getBit(pos)) {
-                        parity ^= 1;
-                    }
+        // Build parity check matrix once per decode
+        ParityCheckMatrix pcm;
+        for (int parity_bit : parity_positions) {
+            std::array<uint64_t,2> row{0,0};
+            for (int pos = 1; pos <= TOTAL_BITS - 1; ++pos) {
+                if (pos & parity_bit) {
+                    int idx = pos - 1;
+                    if (idx < 64)
+                        row[0] |= (1ULL << idx);
+                    else
+                        row[1] |= (1ULL << (idx-64));
                 }
             }
-            
-            if (parity != 0) {
+            pcm.rows.push_back(row);
+        }
+
+        BitVector cwVec;
+        for (int pos = 1; pos <= TOTAL_BITS - 1; ++pos) {
+            if (received.getBit(pos))
+                cwVec.set(pos-1, true);
+        }
+
+        BitVector synVec = pcm.syndrome(cwVec);
+        for (int i = 0; i < PARITY_BITS; ++i) {
+            if (synVec.get(i))
                 result.syndrome |= (1 << i);
-            }
         }
         
         // Calculate overall parity

--- a/ParityCheckMatrix.hpp
+++ b/ParityCheckMatrix.hpp
@@ -1,0 +1,26 @@
+#ifndef PARITYCHECKMATRIX_HPP
+#define PARITYCHECKMATRIX_HPP
+
+#include <array>
+#include <cstdint>
+#include <vector>
+#include "BitVector.hpp"
+
+class ParityCheckMatrix {
+public:
+    std::vector<std::array<uint64_t,2>> rows;  // up to 128 cols
+
+    BitVector syndrome(const BitVector& cw) const {
+        BitVector syn;
+        for (std::size_t i = 0; i < rows.size(); ++i) {
+            uint64_t a = rows[i][0] & cw.words[0];
+            uint64_t b = rows[i][1] & cw.words[1];
+            unsigned parity = __builtin_popcountll(a) + __builtin_popcountll(b);
+            if (parity & 1)
+                syn.set(i, true);
+        }
+        return syn;
+    }
+};
+
+#endif // PARITYCHECKMATRIX_HPP


### PR DESCRIPTION
## Summary
- implement a tiny `BitVector` helper
- add `ParityCheckMatrix` with a `syndrome()` method
- compute syndrome in Hamming decoders via `ParityCheckMatrix`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862a9db2af0832e897c7bb01d986173