### PR TITLE
Add gtest target and run unit tests via make

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,15 +13,15 @@ make
 This produces the following binaries in the repository root:
 `BCHvsHamming`, `Hamming32bit1Gb`, `Hamming64bit128Gb`, and `SATDemo`.
 
-## Running smoke tests
+## Running tests
 
-A small smoke test is available to ensure the binaries start up correctly.
-After building the project simply run:
+The project includes a small smoke test as well as a GoogleTest based unit
+test. Both are executed via the Makefile:
 
 ```bash
 make test
 ```
 
-The `test` target invokes `tests/smoke_test.sh` which runs each binary
-with a 5‑second timeout. If all programs exit successfully the script
-prints `All smoke tests passed.`.
+The `test` rule first builds and runs the unit tests using CMake's `ctest`
+(via the `gtest` target) and then executes `tests/smoke_test.sh`. If all
+programs exit successfully the script prints `All smoke tests passed.`.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ SATDemo: SAT.cpp
 clean:
 	rm -f $(BINARIES)
 
-.PHONY: test clean
+.PHONY: test clean gtest
 
-test: all
+gtest:
+	cmake -S . -B build
+	cmake --build build
+	cd build && ctest --output-on-failure
+
+test: all gtest
 	./tests/smoke_test.sh

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ that it meets your requirements.
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on building the
-project with the provided Makefile and running the smoke test suite.
+project with the provided Makefile and running the full test suite.
 
 ## License
 


### PR DESCRIPTION
## Summary
- integrate GoogleTest build via CMake
- call CTest and smoke tests from `make test`
- document updated testing workflow

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863eb0dae04832ea4912890def723cc