### PR TITLE
Add pytest tests for energy and ECC selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ clean:
 
 test: all
 	./tests/smoke_test.sh
+	PYTHONPATH=. pytest -q tests/python

--- a/tests/python/test_ecc_selector.py
+++ b/tests/python/test_ecc_selector.py
@@ -1,0 +1,15 @@
+from ecc_selector import select_ecc
+
+
+def test_select_ecc_taec_choice():
+    ecc = select_ecc(
+        ber=1e-6,
+        burst_length=2,
+        vdd=0.6,
+        energy_budget=2e-15,
+        sustainability_mode=False,
+        required_correction=1,
+    )
+    assert ecc is not None
+    assert ecc.ecc_type == "TAEC"
+    assert ecc.code == "(75,64)-I6"

--- a/tests/python/test_energy_model.py
+++ b/tests/python/test_energy_model.py
@@ -1,0 +1,13 @@
+import pytest
+from energy_model import estimate_energy, ENERGY_PER_XOR, ENERGY_PER_AND
+
+
+def test_estimate_energy_basic():
+    assert estimate_energy(4, 2) == pytest.approx(4 * ENERGY_PER_XOR + 2 * ENERGY_PER_AND)
+
+
+def test_estimate_energy_negative_inputs():
+    with pytest.raises(ValueError):
+        estimate_energy(-1, 0)
+    with pytest.raises(ValueError):
+        estimate_energy(0, -1)


### PR DESCRIPTION
## Summary
- add basic pytest suite for `energy_model` and `ecc_selector`
- integrate Python tests into `make test`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6863eb12998c832e9313243a3d13f810