### PR TITLE
Extend codeword size in SecDaec64

### DIFF
--- a/tests/unit/SecDaec64_test.cpp
+++ b/tests/unit/SecDaec64_test.cpp
@@ -7,8 +7,8 @@ TEST(SecDaec64, AdjacentDataPairErrors) {
     auto dataPos = codec.getDataPositions();
     for(size_t i=0; i+1<dataPos.size(); ++i) {
         SecDaec64::CodeWord cw = clean;
-        cw.bits ^= 1ULL << dataPos[i];
-        cw.bits ^= 1ULL << dataPos[i+1];
+        cw.bits.set(dataPos[i], !cw.bits.get(dataPos[i]));
+        cw.bits.set(dataPos[i+1], !cw.bits.get(dataPos[i+1]));
         auto res = codec.decode(cw);
         ASSERT_TRUE(res.detected) << "Decoder failed to detect corruption at pair index " << i;
     }


### PR DESCRIPTION
## Summary
- store SecDaec64 codeword bits in a BitVector rather than a single `uint64_t`
- update encode/decode logic for the new representation
- adjust placement of data bits
- tweak unit test to use BitVector API

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6863eafbd428832e849cc157acd8d864