### PR TITLE
Add optional million-word stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ errors were corrected or detected during the test.
 It also reports an estimated energy cost for all read operations using
 constants derived from recent CMOS literature.
 
+The simulator also provides an optional `One Million Read/Write Stress Test`
+that sequentially writes and verifies one million random 64-bit words
+without injecting faults. Set the environment variable `RUN_STRESS_TEST=1`
+before running the binary to enable this check. It exercises the memory
+allocator and decoder under a heavy access workload.
+
 ## Running the 32-bit memory simulator
 
 1. Compile the simulator:


### PR DESCRIPTION
## Summary
- add configurable one million read/write stress test to Hamming64bit128Gb simulator
- allow running the stress test when `RUN_STRESS_TEST=1`
- document the new test in the README

## Testing
- `make clean`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863ff50ba38832eb10ce8ee68af0e86