### PR TITLE
Add docstrings to telemetry parser

### DIFF
--- a/parse_telemetry.py
+++ b/parse_telemetry.py
@@ -1,3 +1,12 @@
+"""Utilities for parsing telemetry logs and reporting energy use.
+
+The telemetry CSV is expected to contain three columns labelled ``xor``,
+``and`` and ``corrections`` with no header row.  ``compute_epc`` parses this
+file, totals the gate counts and reports both the total energy consumed and the
+energy required per corrected bit.  Executing this module as a script prints
+these values to ``stdout``.
+"""
+
 import argparse
 from pathlib import Path
 
@@ -7,6 +16,31 @@ from energy_model import estimate_energy
 
 
 def compute_epc(csv_path: str | Path, node_nm: int, vdd: float) -> tuple[float, float]:
+    """Return the total energy and energy per correction for a telemetry log.
+
+    Parameters
+    ----------
+    csv_path : str or Path
+        Path to the CSV file containing ``xor``, ``and`` and ``corrections``
+        columns without a header row.
+    node_nm : int
+        Technology node in nanometres used for the energy model.
+    vdd : float
+        Supply voltage in volts.
+
+    Returns
+    -------
+    tuple of float
+        ``(total_energy, epc)`` where ``total_energy`` is the sum of energy for
+        all operations in joules and ``epc`` is the energy per corrected bit in
+        joules/bit.
+
+    Raises
+    ------
+    ValueError
+        If the total number of corrections is not positive.
+    """
+
     df = pd.read_csv(csv_path, names=["xor", "and", "corrections"])
     xor_cnt = df["xor"].sum()
     and_cnt = df["and"].sum()


### PR DESCRIPTION
## Summary
- document telemetry parser module usage
- add argument and return descriptions for `compute_epc`

## Testing
- `pip install -q -r requirements.txt`
- `export PYTHONPATH=.`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfa53dfb8832e8d406bc3ea7b3ed1