### PR TITLE
Add ValueError tests for energy_model and telemetry

### DIFF
--- a/tests/python/__init__.py
+++ b/tests/python/__init__.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+root = Path(__file__).resolve().parents[2]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/tests/python/test_energy_model_errors.py
+++ b/tests/python/test_energy_model_errors.py
@@ -1,0 +1,12 @@
+import pytest
+from energy_model import estimate_energy
+
+
+def test_estimate_energy_negative_parity():
+    with pytest.raises(ValueError):
+        estimate_energy(-1, 0)
+
+
+def test_estimate_energy_negative_errors():
+    with pytest.raises(ValueError):
+        estimate_energy(0, -1)

--- a/tests/python/test_parse_telemetry.py
+++ b/tests/python/test_parse_telemetry.py
@@ -14,3 +14,10 @@ def test_compute_epc_sample():
     expected_energy = estimate_energy(10000, 5000, node_nm=16, vdd=0.7)
     assert energy == pytest.approx(expected_energy)
     assert epc_val == pytest.approx(expected_energy / 100, abs=1e-15)
+
+
+def test_compute_epc_no_corrections(tmp_path):
+    csv = tmp_path / "data.csv"
+    csv.write_text("0,0,0\n")
+    with pytest.raises(ValueError):
+        compute_epc(csv, 16, 0.7)


### PR DESCRIPTION
## Summary
- add missing error handling tests to energy_model
- cover compute_epc with zero corrections
- ensure tests package adds repo root to `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfa5bc21c832ea8eba9953fff13a5