### PR TITLE
Add eccsim version CLI and label configuration

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,21 @@
+- name: calibration
+  color: bfd4f2
+  description: Calibration related tasks
+- name: reliability
+  color: fef2c0
+  description: Reliability improvements
+- name: selector
+  color: f9d0c4
+  description: ECC selector components
+- name: telemetry
+  color: d4c5f9
+  description: Telemetry and logging
+- name: validation
+  color: c2e0c6
+  description: Validation and verification
+- name: docs
+  color: fef2c0
+  description: Documentation updates
+- name: CI
+  color: cfd3d7
+  description: Continuous integration

--- a/eccsim.py
+++ b/eccsim.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Command line entry point for ECC simulations.
+
+Currently this binary exposes only version information which combines:
+
+* the Git commit hash,
+* the SHA256 hash of ``tech_calib.json``, and
+* the semantic version string stored in ``VERSION``.
+
+The script will be extended in the future to provide additional simulation
+interfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+def _git_hash() -> str:
+    """Return the current Git commit hash or ``unknown`` if unavailable."""
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return "unknown"
+
+
+def _file_hash(path: Path) -> str:
+    """Return the SHA256 hash for the contents of ``path``."""
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def main() -> None:
+    repo_path = Path(__file__).resolve().parent
+    version_base = (repo_path / "VERSION").read_text().strip()
+    tech_hash = _file_hash(repo_path / "tech_calib.json")
+    git_hash = _git_hash()
+
+    parser = argparse.ArgumentParser(description="ECC simulator")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"{git_hash} {tech_hash} {version_base}",
+    )
+    parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_eccsim_version.py
+++ b/tests/python/test_eccsim_version.py
@@ -1,0 +1,16 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+def test_eccsim_version_prints_three_identifiers():
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout.strip()
+    pattern = r"^[0-9a-f]{40} [0-9a-f]{64} .+"
+    assert re.match(pattern, output)


### PR DESCRIPTION
## Summary
- add `eccsim` CLI with `--version` showing commit, calibration hash, and version
- provide default issue labels for calibration, reliability, selector, telemetry, validation, docs, and CI
- test that `eccsim --version` reports three identifiers

## Testing
- `pytest -q`
- `./eccsim.py --version`
- `curl -X POST https://api.github.com/repos/UNKNOWN/labels -d '{"name":"calibration"}'` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca3ef5834832eb7c7813355a0f436