### PR TITLE
Add ESII calculation and CLI tool

### DIFF
--- a/esii.py
+++ b/esii.py
@@ -1,0 +1,53 @@
+"""Environmental Sustainability Improvement Index (ESII).
+
+This module provides a helper function to compute the ESII given reliability
+improvements and carbon cost components.  The ESII is defined as the ratio of
+failure rate improvement to the total carbon footprint associated with the
+technique.
+"""
+
+from __future__ import annotations
+
+def compute_esii(
+    fit_base: float,
+    fit_ecc: float,
+    E_dyn_kWh: float,
+    E_leak_kWh: float,
+    CI: float,
+    EC_embodied_kg: float,
+) -> float:
+    """Compute the Environmental Sustainability Improvement Index (ESII).
+
+    Parameters
+    ----------
+    fit_base : float
+        Failure rate in FIT (failures per 1e9 hours) for the baseline system.
+    fit_ecc : float
+        Failure rate in FIT when error correction is applied.
+    E_dyn_kWh : float
+        Dynamic energy consumption over the lifetime in kWh.
+    E_leak_kWh : float
+        Leakage energy consumption over the lifetime in kWh.
+    CI : float
+        Carbon intensity in kgCO2e per kWh.
+    EC_embodied_kg : float
+        Embodied carbon of the technique in kgCO2e.
+
+    Returns
+    -------
+    float
+        The ESII value which represents reliability improvement per kgCO2e.
+    """
+    if CI < 0 or E_dyn_kWh < 0 or E_leak_kWh < 0 or EC_embodied_kg < 0:
+        raise ValueError("Energy and carbon terms must be non-negative")
+    if fit_base < fit_ecc:
+        raise ValueError("ECC must not worsen the FIT")
+
+    dynamic = E_dyn_kWh * CI
+    leakage = E_leak_kWh * CI
+    total_carbon = dynamic + leakage + EC_embodied_kg
+    if total_carbon <= 0:
+        raise ValueError("Total carbon must be positive")
+
+    reliability_gain = fit_base - fit_ecc
+    return reliability_gain / total_carbon

--- a/tests/python/test_esii.py
+++ b/tests/python/test_esii.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+from pathlib import Path
+import math
+
+from esii import compute_esii
+
+
+def test_compute_esii():
+    result = compute_esii(1000, 100, 1.0, 0.5, 0.2, 10)
+    expected = 900 / 10.3
+    assert math.isclose(result, expected)
+
+
+def test_cli_esii_outputs_result():
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "esii",
+        "--fit-base",
+        "1000",
+        "--fit-ecc",
+        "100",
+        "--E-dyn",
+        "1",
+        "--E-leak",
+        "0.5",
+        "--ci",
+        "0.2",
+        "--EC-embodied",
+        "10",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    first_line = res.stdout.splitlines()[0]
+    assert first_line == "ESII: 87.379"


### PR DESCRIPTION
## Summary
- add `compute_esii` for Environmental Sustainability Improvement Index calculations
- extend `eccsim` CLI with `esii` subcommand to compute and display ESII metrics and breakdown
- include tests for ESII logic and CLI output

## Testing
- `pytest -q`
- `python eccsim.py esii --fit-base 1000 --fit-ecc 100 --E-dyn 1 --E-leak 0.5 --ci 0.2 --EC-embodied 10`


------
https://chatgpt.com/codex/tasks/task_e_689ca61524e0832e85d26222c79fc4a5