### PR TITLE
feat: add JSON output to reliability report

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ $ jq '.ber' ecc_stats.json
 0.000023
 ```
 
+## Reliability report
+
+The `eccsim` CLI can generate a reliability summary. Adding `--json` emits a
+machine-readable version alongside the human table:
+
+```bash
+$ python eccsim.py reliability report --qcrit 1.2 --qs 0.25 --area 0.08 --flux-rel 1 --json
+```
+
+With `--json` the table is printed to stderr and the JSON object to stdout so it
+can be piped directly into other tools.
+
 ## Running the BCH vs Hamming comparison
 
 1. Compile the simulator:

--- a/tests/python/test_reliability_report_cli.py
+++ b/tests/python/test_reliability_report_cli.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from ser_model import HazuchaParams, ser_hazucha
+
+
+def test_reliability_report_json():
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "reliability",
+        "report",
+        "--qcrit",
+        "1.2",
+        "--qs",
+        "0.25",
+        "--area",
+        "0.08",
+        "--flux-rel",
+        "1.0",
+        "--scrub-interval",
+        "3600",
+        "--capacity-gib",
+        "1.0",
+        "--json",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(res.stdout)
+    hp = HazuchaParams(Qs_fC=0.25, flux_rel=1.0, area_um2=0.08)
+    expected = ser_hazucha(1.2, hp)
+    assert data["fit_bit"] == pytest.approx(expected)
+    assert "fit_bit" in res.stderr


### PR DESCRIPTION
## Summary
- add `reliability report` subcommand with optional `--json` output
- document CLI usage and JSON behavior
- test reliability report JSON output

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ce18aa390832e8c3e7e5039c47e67