### PR TITLE
Add strict Qcrit schema and validate lookup loader

### DIFF
--- a/data/qcrit_sram6t.json
+++ b/data/qcrit_sram6t.json
@@ -1,49 +1,38 @@
 {
-  "meta": {
-    "description": "Placeholder critical charge table for 6T SRAM cells",
-    "units": {
-      "node_nm": "nm",
-      "vdd": "V",
-      "tempC": "C",
-      "pulse_rise_ps": "ps",
-      "qcrit": "fC"
-    }
+  "schema_version": "1.0",
+  "element": "sram6t",
+  "tech_family": "finfet",
+  "units": {
+    "vdd": "V",
+    "tempC": "°C",
+    "pulse_rise_ps": "ps",
+    "pulse_fall_ps": "ps",
+    "qcrit": "fC",
+    "sensitive_area_um2": "µm²"
   },
-  "data": {
-    "22": {
-      "0.6": {
-        "-40": {
-          "10": {"min": 0.81, "mean": 0.9, "max": 0.99}
-        },
-        "25": {
-          "10": {"min": 1.395, "mean": 1.55, "max": 1.705}
-        },
-        "125": {
-          "10": {"min": 2.295, "mean": 2.55, "max": 2.805}
-        }
-      },
-      "0.8": {
-        "-40": {
-          "10": {"min": 0.9, "mean": 1.0, "max": 1.1}
-        },
-        "25": {
-          "10": {"min": 1.485, "mean": 1.65, "max": 1.815}
-        },
-        "125": {
-          "10": {"min": 2.385, "mean": 2.65, "max": 2.915}
-        }
-      },
-      "1.0": {
-        "-40": {
-          "10": {"min": 0.99, "mean": 1.1, "max": 1.21}
-        },
-        "25": {
-          "10": {"min": 1.575, "mean": 1.75, "max": 1.925}
-        },
-        "125": {
-          "10": {"min": 2.475, "mean": 2.75, "max": 3.025}
-        }
-      }
+  "interpolation": { "vdd": "linear", "tempC": "linear", "extrapolation_policy": "warn-clamp" },
+  "entries": [
+    {
+      "node_nm": 14,
+      "vdd": 0.80,
+      "tempC": 75,
+      "pulse_rise_ps": 50,
+      "pulse_fall_ps": 200,
+      "bias": "hold",
+      "qcrit": { "mean_fC": 0.28, "min_fC": 0.24, "max_fC": 0.33, "stdev_fC": 0.02 },
+      "sensitive_area_um2": 0.06,
+      "method": "SPICE-DEXP",
+      "source": "Hazucha-style extraction; lab sweep run #A17",
+      "url": "https://example.org/qcrit-a17",
+      "date": "2025-08-13",
+      "temperature_ref": "junction",
+      "comments": "Nominal read stability; 6T cell; FO=1."
     }
+  ],
+  "provenance": {
+    "owner": "Your Lab / University",
+    "contact": "abhinav@example.edu",
+    "license": "CC-BY-4.0",
+    "citation": "Your internal report or published source"
   }
 }

--- a/data/qcrit_sram6t.schema.json
+++ b/data/qcrit_sram6t.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AbhinavChoudhary24167/Error-Code-Correction",
+  "title": "Qcrit lookup table for SRAM 6T cells (strict v1.0)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "element", "tech_family", "units", "interpolation", "entries", "provenance"],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0" },
+    "element": { "type": "string", "const": "sram6t" },
+    "tech_family": { "type": "string", "enum": ["bulk_planar", "finfet", "fdsoi"] },
+    "notes": { "type": "string" },
+    "units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vdd", "tempC", "pulse_rise_ps", "pulse_fall_ps", "qcrit", "sensitive_area_um2"],
+      "properties": {
+        "vdd": { "type": "string", "const": "V" },
+        "tempC": { "type": "string", "const": "°C" },
+        "pulse_rise_ps": { "type": "string", "const": "ps" },
+        "pulse_fall_ps": { "type": "string", "const": "ps" },
+        "qcrit": { "type": "string", "const": "fC" },
+        "sensitive_area_um2": { "type": "string", "const": "µm²" }
+      }
+    },
+    "interpolation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vdd", "tempC"],
+      "properties": {
+        "vdd": { "type": "string", "enum": ["linear", "pwl"] },
+        "tempC": { "type": "string", "enum": ["linear", "pwl"] },
+        "extrapolation_policy": { "type": "string", "enum": ["error", "clamp", "warn-clamp"], "default": "warn-clamp" }
+      }
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/QcritEntry" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "license"],
+      "properties": {
+        "owner": { "type": "string", "minLength": 1 },
+        "contact": { "type": "string" },
+        "license": { "type": "string", "enum": ["CC-BY-4.0", "CC0-1.0", "Proprietary", "Other"] },
+        "citation": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "QcritStats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mean_fC"],
+      "properties": {
+        "mean_fC": { "type": "number", "exclusiveMinimum": 0 },
+        "min_fC": { "type": "number", "exclusiveMinimum": 0 },
+        "max_fC": { "type": "number", "exclusiveMinimum": 0 },
+        "stdev_fC": { "type": "number", "minimum": 0 }
+      }
+    },
+    "QcritEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["node_nm", "vdd", "tempC", "pulse_rise_ps", "pulse_fall_ps", "bias", "qcrit", "source", "date"],
+      "properties": {
+        "node_nm": { "type": "integer", "minimum": 3, "maximum": 180, "multipleOf": 1 },
+        "vdd": { "type": "number", "exclusiveMinimum": 0.2, "exclusiveMaximum": 2.0 },
+        "tempC": { "type": "number", "minimum": -55, "maximum": 175 },
+        "pulse_rise_ps": { "type": "number", "minimum": 1, "maximum": 10000 },
+        "pulse_fall_ps": { "type": "number", "minimum": 1, "maximum": 10000 },
+        "bias": { "type": "string", "enum": ["hold", "read", "write0", "write1"], "default": "hold" },
+        "qcrit": { "$ref": "#/$defs/QcritStats" },
+        "sensitive_area_um2": { "type": "number", "exclusiveMinimum": 0 },
+        "method": { "type": "string", "enum": ["SPICE-DEXP", "SPICE-HeavyIon", "TCAD", "Measured"] },
+        "source": { "type": "string", "minLength": 3 },
+        "url": { "type": "string", "format": "uri" },
+        "doi": { "type": "string" },
+        "date": { "type": "string", "format": "date" },
+        "temperature_ref": { "type": "string", "enum": ["junction", "ambient"], "default": "junction" },
+        "comments": { "type": "string" }
+      }
+    }
+  }
+}

--- a/data/qcrit_sram6t.schema.light.json
+++ b/data/qcrit_sram6t.schema.light.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://your.org/schemas/qcrit_sram6t.schema.light.json",
+  "title": "Qcrit lookup table for SRAM 6T cells (light)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "element", "tech_family", "entries"],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "element": { "type": "string" },
+    "tech_family": { "type": "string" },
+    "units": { "type": "object" },
+    "interpolation": { "type": "object" },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["node_nm", "vdd", "tempC", "pulse_rise_ps", "qcrit", "source", "date"],
+        "properties": {
+          "node_nm": { "type": "integer" },
+          "vdd": { "type": "number" },
+          "tempC": { "type": "number" },
+          "pulse_rise_ps": { "type": "number" },
+          "pulse_fall_ps": { "type": "number" },
+          "bias": { "type": "string" },
+          "qcrit": {
+            "type": "object",
+            "required": ["mean_fC"],
+            "properties": {
+              "mean_fC": { "type": "number" },
+              "min_fC": { "type": "number" },
+              "max_fC": { "type": "number" },
+              "stdev_fC": { "type": "number" }
+            }
+          },
+          "sensitive_area_um2": { "type": "number" },
+          "method": { "type": "string" },
+          "source": { "type": "string" },
+          "url": { "type": "string" },
+          "doi": { "type": "string" },
+          "date": { "type": "string" },
+          "temperature_ref": { "type": "string" },
+          "comments": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "provenance": { "type": "object" }
+  }
+}

--- a/ser_model.py
+++ b/ser_model.py
@@ -24,6 +24,7 @@ import math
 from pathlib import Path
 import warnings
 from typing import Dict, List, Tuple
+import jsonschema
 
 # Default Markov parameters derived from the thesis tables.
 DEFAULT_PARAMS: Dict[str, float] = {
@@ -102,24 +103,62 @@ _QCRIT_CACHE: Dict[str, dict] = {}
 
 
 def _load_qcrit_table(element: str) -> dict:
-    """Load and cache Qcrit tables for a given element."""
+    """Load, validate and cache Qcrit tables for a given element."""
 
-    if element not in _QCRIT_CACHE:
-        data_path = Path(__file__).with_name("data") / f"qcrit_{element}.json"
-        with data_path.open("r", encoding="utf-8") as fh:
-            _QCRIT_CACHE[element] = json.load(fh)
+    if element in _QCRIT_CACHE:
+        return _QCRIT_CACHE[element]
+
+    data_dir = Path(__file__).with_name("data")
+    data_path = data_dir / f"qcrit_{element}.json"
+    schema_path = data_dir / f"qcrit_{element}.schema.json"
+
+    with data_path.open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+
+    # Validate against the strict schema
+    with schema_path.open("r", encoding="utf-8") as sfh:
+        schema = json.load(sfh)
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.validate(raw)
+
+    # Enforce composite key uniqueness and reshape for lookup
+    grid: Dict[int, Dict[float, Dict[float, Dict[float, dict]]]] = {}
+    seen = set()
+    for e in raw["entries"]:
+        key = (e["node_nm"], e["vdd"], e["tempC"], e["pulse_rise_ps"])
+        if key in seen:
+            raise ValueError(f"Duplicate Qcrit entry for {key}")
+        seen.add(key)
+
+        node = grid.setdefault(e["node_nm"], {})
+        v_map = node.setdefault(e["vdd"], {})
+        t_map = v_map.setdefault(e["tempC"], {})
+        t_map[e["pulse_rise_ps"]] = e["qcrit"]
+
+    _QCRIT_CACHE[element] = {
+        "interpolation": raw.get("interpolation", {}),
+        "data": grid,
+    }
     return _QCRIT_CACHE[element]
 
 
-def _find_bounds(value: float, points: List[float]) -> Tuple[float, float]:
-    """Return surrounding grid points, warning when ``value`` is out of range."""
+def _find_bounds(value: float, points: List[float], policy: str) -> Tuple[float, float]:
+    """Return surrounding grid points respecting an extrapolation policy."""
 
-    if value <= points[0]:
-        warnings.warn("Value below table range", RuntimeWarning)
+    if value < points[0]:
+        if policy == "error":
+            raise ValueError("Value below table range")
+        if policy == "warn-clamp":
+            warnings.warn("Value below table range", RuntimeWarning)
         return points[0], points[0]
-    if value >= points[-1]:
-        warnings.warn("Value above table range", RuntimeWarning)
+
+    if value > points[-1]:
+        if policy == "error":
+            raise ValueError("Value above table range")
+        if policy == "warn-clamp":
+            warnings.warn("Value above table range", RuntimeWarning)
         return points[-1], points[-1]
+
     lo = points[0]
     for hi in points[1:]:
         if hi >= value:
@@ -145,20 +184,23 @@ def qcrit_lookup(
     requested point lies outside the available table range.
     """
 
-    table = _load_qcrit_table(element)["data"]
-    node = table[str(node_nm)]
-    pulse_key = str(pulse_ps)
+    qcrit_table = _load_qcrit_table(element)
+    table = qcrit_table["data"]
+    policy = qcrit_table.get("interpolation", {}).get(
+        "extrapolation_policy", "warn-clamp"
+    )
 
-    v_map = {float(k): k for k in node.keys()}
-    v_vals = sorted(v_map.keys())
-    v_lo, v_hi = _find_bounds(vdd, v_vals)
+    node = table[node_nm]
+    pulse_key = pulse_ps
 
-    t_map = {float(k): k for k in node[v_map[v_lo]].keys()}
-    t_vals = sorted(t_map.keys())
-    t_lo, t_hi = _find_bounds(tempC, t_vals)
+    v_vals = sorted(node.keys())
+    v_lo, v_hi = _find_bounds(vdd, v_vals, policy)
+
+    t_vals = sorted(node[v_lo].keys())
+    t_lo, t_hi = _find_bounds(tempC, t_vals, policy)
 
     def value(v: float, t: float) -> float:
-        return node[v_map[v]][t_map[t]][pulse_key]["mean"]
+        return node[v][t][pulse_key]["mean_fC"]
 
     if v_lo == v_hi and t_lo == t_hi:
         return value(v_lo, t_lo)

--- a/tests/python/test_qcrit_lookup.py
+++ b/tests/python/test_qcrit_lookup.py
@@ -2,12 +2,12 @@ import pytest
 from ser_model import qcrit_lookup
 
 
-def test_interpolation_within_grid():
-    val = qcrit_lookup("sram6t", 22, 0.7, 0.0, 10)
-    expected = 1.0 + 0.5 * 0.7 + 0.01 * 0.0
-    assert val == pytest.approx(expected, rel=1e-5)
+def test_direct_lookup():
+    val = qcrit_lookup("sram6t", 14, 0.80, 75, 50)
+    assert val == pytest.approx(0.28, rel=1e-6)
 
 
-def test_out_of_bounds_warning():
+def test_out_of_bounds_warns_and_clamps():
     with pytest.warns(RuntimeWarning):
-        qcrit_lookup("sram6t", 22, 1.2, 0.0, 10)
+        val = qcrit_lookup("sram6t", 14, 0.90, 75, 50)
+    assert val == pytest.approx(0.28, rel=1e-6)


### PR DESCRIPTION
## Summary
- add strict and light JSON Schemas for SRAM 6T Qcrit tables
- validate Qcrit data against schema and enforce grid uniqueness in `ser_model`
- replace Qcrit data file and add tests for lookup and extrapolation policy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ce4e09578832ea8befbd5a20dacac