### PR TITLE
Enforce required fields in Qcrit loader

### DIFF
--- a/qcrit_loader.py
+++ b/qcrit_loader.py
@@ -42,9 +42,9 @@ def _load_qcrit_table(element: str) -> dict:
     grid: Dict[int, Dict[float, Dict[float, Dict[float, dict]]]] = {}
     seen = set()
     for e in raw["entries"]:
-        for field in ("method", "source", "date"):
+        for field in ("method", "source", "date", "tempC", "vdd"):
             if field not in e:
-                raise ValueError(f"Unprovenanced Qcrit entry missing {field}")
+                raise ValueError(f"Qcrit entry missing required field '{field}'")
         key = (e["node_nm"], e["vdd"], e["tempC"], e["pulse_rise_ps"])
         if key in seen:
             raise ValueError(f"Duplicate Qcrit entry for {key}")

--- a/tests/python/test_qcrit_lookup.py
+++ b/tests/python/test_qcrit_lookup.py
@@ -1,4 +1,7 @@
+import json
+
 import pytest
+import qcrit_loader
 from ser_model import qcrit_lookup
 
 
@@ -11,3 +14,44 @@ def test_out_of_bounds_warns_and_clamps():
     with pytest.warns(RuntimeWarning):
         val = qcrit_lookup("sram6t", 14, 0.90, 75, 50)
     assert val == pytest.approx(0.28, rel=1e-6)
+
+
+def test_missing_temp_field(monkeypatch, tmp_path):
+    element = "bad"
+    data_dir = tmp_path / "data"
+    schema_dir = tmp_path / "schemas"
+    data_dir.mkdir()
+    schema_dir.mkdir()
+
+    data = {
+        "units": {"qcrit": "fC"},
+        "entries": [
+            {
+                "node_nm": 14,
+                "vdd": 0.8,
+                "pulse_rise_ps": 50,
+                "method": "sim",
+                "source": "test",
+                "date": "2023-01-01",
+                "qcrit": {"mean_fC": 0.28},
+            }
+        ],
+    }
+    (data_dir / f"qcrit_{element}.json").write_text(json.dumps(data))
+
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+            "units": {"type": "object"},
+            "entries": {"type": "array", "items": {"type": "object"}},
+        },
+        "required": ["units", "entries"],
+    }
+    (schema_dir / f"qcrit_{element}.schema.json").write_text(json.dumps(schema))
+
+    monkeypatch.setattr(qcrit_loader, "__file__", str(tmp_path / "qcrit_loader.py"))
+    qcrit_loader._QCRIT_CACHE.clear()
+
+    with pytest.raises(ValueError, match="tempC"):
+        qcrit_loader._load_qcrit_table(element)


### PR DESCRIPTION
## Summary
- ensure Qcrit entries include tempC and vdd
- raise clear errors when required fields are absent
- add test covering missing tempC

## Testing
- `pytest tests/python/test_qcrit_lookup.py -q`
- `pytest tests/python -q`


------
https://chatgpt.com/codex/tasks/task_e_689ceb72d87c832e9f510954a6532a96