### PR TITLE
Add uncertainty support to FIT calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ $ jq '.ber' ecc_stats.json
 
 ## Reliability report
 
-The `eccsim` CLI can generate a reliability summary. Adding `--json` emits a
-machine-readable version alongside the human table:
+The `eccsim` CLI can generate a reliability summary. The underlying
+`compute_fit_pre` and `compute_fit_post` helpers now return a small dataclass
+containing the nominal FIT value and an optional standard deviation. This makes
+it straightforward to reason about uncertainty and report results as ranges
+rather than single figures. Adding `--json` emits a machine-readable version
+alongside the human table:
 
 ```bash
 $ python eccsim.py reliability report --qcrit 1.2 --qs 0.25 --area 0.08 --flux-rel 1 --json
@@ -32,6 +36,23 @@ $ python eccsim.py reliability report --qcrit 1.2 --qs 0.25 --area 0.08 --flux-r
 
 With `--json` the table is printed to stderr and the JSON object to stdout so it
 can be piped directly into other tools.
+
+Example of inspecting the uncertainty returned from ``compute_fit_post``:
+
+```python
+from fit import compute_fit_post, ecc_coverage_factory
+
+fit = compute_fit_post(
+    64,
+    10.0,
+    {2: {"adj": 5.0}},
+    ecc_coverage_factory("SEC-DED"),
+    scrub_interval_s=0.0,
+    fit_bit_stddev=1.0,
+    mbu_rates_stddev_by_k={2: {"adj": 0.5}},
+)
+print(f"FIT: {fit.nominal:.1f} ± {fit.stddev:.1f}")
+```
 
 ## Running the BCH vs Hamming comparison
 

--- a/tests/python/test_fit.py
+++ b/tests/python/test_fit.py
@@ -21,10 +21,15 @@ def test_sec_daec_benefits_from_adjacent_bursts():
     ded = ecc_coverage_factory("SEC-DED")
     daec = ecc_coverage_factory("SEC-DAEC")
 
-    sys_ded_low = fit_system(1.0, compute_fit_post(word_bits, fit_bit, rates_low, ded, scrub))
-    sys_daec_low = fit_system(1.0, compute_fit_post(word_bits, fit_bit, rates_low, daec, scrub))
-    sys_ded_high = fit_system(1.0, compute_fit_post(word_bits, fit_bit, rates_high, ded, scrub))
-    sys_daec_high = fit_system(1.0, compute_fit_post(word_bits, fit_bit, rates_high, daec, scrub))
+    ded_low = compute_fit_post(word_bits, fit_bit, rates_low, ded, scrub)
+    daec_low = compute_fit_post(word_bits, fit_bit, rates_low, daec, scrub)
+    ded_high = compute_fit_post(word_bits, fit_bit, rates_high, ded, scrub)
+    daec_high = compute_fit_post(word_bits, fit_bit, rates_high, daec, scrub)
+
+    sys_ded_low = fit_system(1.0, ded_low).nominal
+    sys_daec_low = fit_system(1.0, daec_low).nominal
+    sys_ded_high = fit_system(1.0, ded_high).nominal
+    sys_daec_high = fit_system(1.0, daec_high).nominal
 
     diff_low = sys_ded_low - sys_daec_low
     diff_high = sys_ded_high - sys_daec_high
@@ -43,10 +48,10 @@ def test_scrub_interval_increases_residual_doubles():
     short = compute_fit_post(word_bits, fit_bit, rates, ded, scrub_interval_s=3600)
     long = compute_fit_post(word_bits, fit_bit, rates, ded, scrub_interval_s=3600 * 10)
 
-    assert long > short
+    assert long.nominal > short.nominal
 
-    sys_short = fit_system(1.0, short)
-    sys_long = fit_system(1.0, long)
+    sys_short = fit_system(1.0, short).nominal
+    sys_long = fit_system(1.0, long).nominal
 
     assert sys_long > sys_short
 
@@ -59,4 +64,34 @@ def test_mttf_from_fit():
 def test_compute_fit_pre():
     fit_bit = 10.0
     mbu = {2: {"adj": 5.0, "nonadj": 5.0}, 3: 1.0}
-    assert compute_fit_pre(64, fit_bit, mbu) == 64 * 10.0 + 5.0 + 5.0 + 1.0
+    res = compute_fit_pre(64, fit_bit, mbu)
+    assert res.nominal == 64 * 10.0 + 5.0 + 5.0 + 1.0
+
+
+def test_compute_fit_pre_uncertainty():
+    fit_bit = 10.0
+    fit_std = 1.0
+    mbu = {2: {"adj": 5.0, "nonadj": 5.0}, 3: 1.0}
+    mbu_std = {2: {"adj": 1.0, "nonadj": 2.0}, 3: 0.5}
+    res = compute_fit_pre(64, fit_bit, mbu, fit_bit_stddev=fit_std, mbu_rates_stddev_by_k=mbu_std)
+    expected = math.sqrt((64 * fit_std) ** 2 + 1.0**2 + 2.0**2 + 0.5**2)
+    assert res.nominal == 64 * 10.0 + 5.0 + 5.0 + 1.0
+    assert math.isclose(res.stddev, expected)
+
+
+def test_compute_fit_post_uncertainty():
+    word_bits = 64
+    fit_bit = 0.0
+    rates = {2: {"adj": 5.0}}
+    rates_std = {2: {"adj": 1.0}}
+    ded = ecc_coverage_factory("SEC-DED")
+    res = compute_fit_post(
+        word_bits,
+        fit_bit,
+        rates,
+        ded,
+        scrub_interval_s=0.0,
+        mbu_rates_stddev_by_k=rates_std,
+    )
+    assert res.nominal == 5.0
+    assert res.stddev == 1.0

--- a/tests/python/test_mbu.py
+++ b/tests/python/test_mbu.py
@@ -35,10 +35,10 @@ def test_heavy_severity_penalises_sec_ded_more():
     taec_light = compute_fit_post(word_bits, fit_bit, rates_light, taec, scrub)
     taec_heavy = compute_fit_post(word_bits, fit_bit, rates_heavy, taec, scrub)
 
-    diff_ded = ded_heavy - ded_light
-    diff_daec = daec_heavy - daec_light
-    diff_taec = taec_heavy - taec_light
+    diff_ded = ded_heavy.nominal - ded_light.nominal
+    diff_daec = daec_heavy.nominal - daec_light.nominal
+    diff_taec = taec_heavy.nominal - taec_light.nominal
 
-    assert ded_heavy > ded_light
+    assert ded_heavy.nominal > ded_light.nominal
     assert diff_ded > diff_daec
     assert diff_ded > diff_taec


### PR DESCRIPTION
## Summary
- Add `FitEstimate` dataclass for nominal FIT and optional standard deviation
- Extend `compute_fit_pre` and `compute_fit_post` to propagate uncertainty
- Update CLI, docs, and tests to report FIT ranges rather than single values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ceb7a4d80832ebec3616cc9a599cb