### PR TITLE
Fix README sustainability typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 See [docs/TestSummary.md](docs/TestSummary.md) for an overview of the simulator tests.
 
-ECC for SRAM, studying the impact of ECC architectures on sustainablity
+ECC for SRAM, studying the impact of ECC architectures on sustainability
 
 Running the simulators now produces several structured result files in the
 repository root:


### PR DESCRIPTION
## Summary
- fix spelling of "sustainability" in project summary

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689ceef2e128832e9d63ad13ac831107