### PR TITLE
Add energy interpolation, leakage model, and CLI

### DIFF
--- a/tech_calib.json
+++ b/tech_calib.json
@@ -4,13 +4,13 @@
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 3.0e-12, "and": 1.5e-12}
+      "gates": {"xor": 3.0e-12, "and": 1.5e-12, "adder_stage": 5.0e-12}
     },
     "0.6": {
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 2.5e-12, "and": 1.2e-12}
+      "gates": {"xor": 2.5e-12, "and": 1.2e-12, "adder_stage": 4.0e-12}
     }
   },
   "16": {
@@ -18,13 +18,13 @@
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 2.0e-12, "and": 1.0e-12}
+      "gates": {"xor": 2.0e-12, "and": 1.0e-12, "adder_stage": 3.0e-12}
     },
     "0.6": {
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 1.5e-12, "and": 0.8e-12}
+      "gates": {"xor": 1.5e-12, "and": 0.8e-12, "adder_stage": 2.4e-12}
     }
   },
   "7": {
@@ -32,13 +32,13 @@
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 1.1e-12, "and": 0.6e-12}
+      "gates": {"xor": 1.1e-12, "and": 0.6e-12, "adder_stage": 1.5e-12}
     },
     "0.6": {
       "source": "ref",
       "date": "2024-01-01",
       "tempC": 25,
-      "gates": {"xor": 0.8e-12, "and": 0.4e-12}
+      "gates": {"xor": 0.8e-12, "and": 0.4e-12, "adder_stage": 1.1e-12}
     }
   }
 }

--- a/tests/python/test_energy.py
+++ b/tests/python/test_energy.py
@@ -1,0 +1,30 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_energy_cli_json(tmp_path):
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        "python3",
+        str(script),
+        "energy",
+        "--code",
+        "sec-daec",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ops",
+        "1e3",
+        "--lifetime-h",
+        "1",
+        "--report",
+        "json",
+    ]
+    out = subprocess.check_output(cmd)
+    data = json.loads(out)
+    assert "dynamic_kWh" in data
+    assert "leakage_kWh" in data

--- a/tests/python/test_energy_interp.py
+++ b/tests/python/test_energy_interp.py
@@ -1,0 +1,23 @@
+import pytest
+import energy_model
+
+
+def test_boundary_exactness():
+    e_lo = energy_model.gate_energy(28, 0.6, "xor")
+    assert e_lo == pytest.approx(2.5e-12, rel=1e-9)
+    e_hi = energy_model.gate_energy(28, 0.8, "xor")
+    assert e_hi == pytest.approx(3.0e-12, rel=1e-9)
+
+
+def test_interior_linearity():
+    e_lo = energy_model.gate_energy(28, 0.6, "xor")
+    e_hi = energy_model.gate_energy(28, 0.8, "xor")
+    e_mid = energy_model.gate_energy(28, 0.7, "xor")
+    assert e_mid == pytest.approx((e_lo + e_hi) / 2, rel=1e-9)
+
+
+def test_oob_warn_clamp(caplog):
+    with caplog.at_level("WARNING"):
+        e = energy_model.gate_energy(28, 0.5, "xor")
+    assert e == pytest.approx(2.5e-12, rel=1e-9)
+    assert any("clamped" in m for m in caplog.text.splitlines())

--- a/tests/python/test_energy_model_loader.py
+++ b/tests/python/test_energy_model_loader.py
@@ -37,3 +37,25 @@ def test_missing_gate_energy(tmp_path):
     path = _write(tmp_path, data)
     with pytest.raises(ValueError):
         energy_model._load_calib(path)
+
+
+def test_non_monotonic_vdd(tmp_path):
+    data = {
+        "28": {
+            "0.6": {
+                "source": "ref",
+                "date": "2024-01-01",
+                "tempC": 25,
+                "gates": {"xor": 2.0e-12, "and": 1.0e-12, "adder_stage": 3.0e-12},
+            },
+            "0.8": {
+                "source": "ref",
+                "date": "2024-01-01",
+                "tempC": 25,
+                "gates": {"xor": 1.0e-12, "and": 0.5e-12, "adder_stage": 2.0e-12},
+            },
+        }
+    }
+    path = _write(tmp_path, data)
+    with pytest.raises(ValueError):
+        energy_model._load_calib(path)


### PR DESCRIPTION
## Summary
- validate calibration metadata and monotonicity for gate energies across VDD
- clamp out-of-range supply voltages with warnings during piecewise-linear interpolation
- add tests covering interpolation accuracy and energy scaling with operations, temperature, and area

## Testing
- `pytest -q`
- `python3 eccsim.py energy --code sec-daec --node 14 --vdd 0.8 --temp 75 --ops 1e9 --lifetime-h 43800 --report json`


------
https://chatgpt.com/codex/tasks/task_e_689d4d6dc624832e832eac06e78a1dd0