### PR TITLE
Add carbon accounting utilities and CLI

### DIFF
--- a/carbon.py
+++ b/carbon.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Carbon accounting helpers.
+
+This module provides small utilities to estimate the embodied and
+operational carbon associated with an ECC technique or hardware block.
+"""
+
+from pathlib import Path
+import json
+from typing import Tuple
+
+
+def embodied_kg(
+    area_logic_mm2: float,
+    area_macro_mm2: float,
+    alpha_logic_kg_per_mm2: float,
+    alpha_macro_kg_per_mm2: float,
+) -> float:
+    """Return embodied carbon for logic and macro areas.
+
+    Parameters
+    ----------
+    area_logic_mm2 : float
+        Added logic area in square millimetres.
+    area_macro_mm2 : float
+        Added memory macro area in square millimetres.
+    alpha_logic_kg_per_mm2 : float
+        Embodied carbon factor for logic in ``kgCO2e/mm²``.
+    alpha_macro_kg_per_mm2 : float
+        Embodied carbon factor for macros in ``kgCO2e/mm²``.
+
+    Returns
+    -------
+    float
+        Total embodied carbon in kilograms of CO2e.
+    """
+
+    if (
+        area_logic_mm2 < 0
+        or area_macro_mm2 < 0
+        or alpha_logic_kg_per_mm2 < 0
+        or alpha_macro_kg_per_mm2 < 0
+    ):
+        raise ValueError("areas and alpha factors must be non-negative")
+
+    return area_logic_mm2 * alpha_logic_kg_per_mm2 + area_macro_mm2 * alpha_macro_kg_per_mm2
+
+
+def operational_kg(E_dyn_kWh: float, E_leak_kWh: float, CI_kg_per_kWh: float) -> float:
+    """Return operational carbon given energy terms and carbon intensity."""
+    if E_dyn_kWh < 0 or E_leak_kWh < 0 or CI_kg_per_kWh < 0:
+        raise ValueError("energy and carbon intensity must be non-negative")
+    return CI_kg_per_kWh * (E_dyn_kWh + E_leak_kWh)
+
+
+def _load_defaults(path: Path) -> dict:
+    """Load alpha defaults from ``carbon_defaults.json``."""
+    data = json.load(open(path))
+    for node_str, entry in data.items():
+        if {"source", "date", "alpha_logic", "alpha_macro"} - entry.keys():
+            raise ValueError(f"Missing fields for node {node_str}")
+    return data
+
+
+_DEFAULTS = _load_defaults(Path(__file__).with_name("carbon_defaults.json"))
+
+
+def default_alpha(node_nm: int) -> Tuple[float, float]:
+    """Return ``(alpha_logic, alpha_macro)`` for the given technology node."""
+    entry = _DEFAULTS[str(int(node_nm))]
+    return entry["alpha_logic"], entry["alpha_macro"]

--- a/carbon_defaults.json
+++ b/carbon_defaults.json
@@ -1,0 +1,20 @@
+{
+  "7": {
+    "source": "placeholder",
+    "date": "2024-01-01",
+    "alpha_logic": 1.0,
+    "alpha_macro": 1.2
+  },
+  "14": {
+    "source": "placeholder",
+    "date": "2024-01-01",
+    "alpha_logic": 0.8,
+    "alpha_macro": 1.0
+  },
+  "28": {
+    "source": "placeholder",
+    "date": "2024-01-01",
+    "alpha_logic": 0.6,
+    "alpha_macro": 0.8
+  }
+}

--- a/tests/python/test_carbon.py
+++ b/tests/python/test_carbon.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from carbon import embodied_kg, operational_kg
+
+
+def test_operational_sign():
+    assert operational_kg(1.0, 0.0, 0.5) == 0.5
+
+
+def test_embodied_additivity():
+    assert embodied_kg(0.1, 0.2, 1.0, 2.0) == 0.1 * 1.0 + 0.2 * 2.0
+
+
+def test_cli_round_trip():
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "carbon",
+        "--areas",
+        "0.05,0.20",
+        "--alpha",
+        "1.5,1.0",
+        "--ci",
+        "0.55",
+        "--Edyn",
+        "0.002",
+        "--Eleak",
+        "0.001",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    lines = res.stdout.strip().splitlines()
+    assert "Embodied" in lines[0]
+    assert "Operational" in lines[1]
+


### PR DESCRIPTION
## Summary
- add `carbon.py` with helpers for embodied and operational carbon
- include placeholder `carbon_defaults.json` with alpha factors per node
- extend `eccsim` CLI with `carbon` subcommand
- test carbon calculations and CLI round-trip

## Testing
- `pytest tests/python/test_carbon.py -q`
- `python eccsim.py carbon --areas 0.05,0.20 --alpha 1.5,1.0 --ci 0.55 --Edyn 0.002 --Eleak 0.001`


------
https://chatgpt.com/codex/tasks/task_e_689d527523e4832ea141832c2907aa1a