### PR TITLE
Refactor ESII computation

### DIFF
--- a/carbon.py
+++ b/carbon.py
@@ -11,7 +11,7 @@ import json
 from typing import Tuple
 
 
-def embodied_kg(
+def embodied_kgco2e(
     area_logic_mm2: float,
     area_macro_mm2: float,
     alpha_logic_kg_per_mm2: float,
@@ -47,11 +47,13 @@ def embodied_kg(
     return area_logic_mm2 * alpha_logic_kg_per_mm2 + area_macro_mm2 * alpha_macro_kg_per_mm2
 
 
-def operational_kg(E_dyn_kWh: float, E_leak_kWh: float, CI_kg_per_kWh: float) -> float:
+def operational_kgco2e(
+    E_dyn_kWh: float, E_leak_kWh: float, CI_kgco2e_per_kWh: float
+) -> float:
     """Return operational carbon given energy terms and carbon intensity."""
-    if E_dyn_kWh < 0 or E_leak_kWh < 0 or CI_kg_per_kWh < 0:
+    if E_dyn_kWh < 0 or E_leak_kWh < 0 or CI_kgco2e_per_kWh < 0:
         raise ValueError("energy and carbon intensity must be non-negative")
-    return CI_kg_per_kWh * (E_dyn_kWh + E_leak_kWh)
+    return CI_kgco2e_per_kWh * (E_dyn_kWh + E_leak_kWh)
 
 
 def _load_defaults(path: Path) -> dict:

--- a/energy_model.py
+++ b/energy_model.py
@@ -255,12 +255,12 @@ def area_overhead_mm2(code: str) -> float:
         raise KeyError(code)
 
 
-def leakage_energy_kwh(
+def leakage_energy_j(
     vdd: float, node_nm: float, temp_c: float, code: str, lifetime_h: float
 ) -> float:
     i = i_leak_density_A_per_mm2(node_nm, temp_c)
     area = area_overhead_mm2(code)
-    return vdd * i * area * (lifetime_h / 1000.0)
+    return vdd * i * area * (lifetime_h * 3600.0)
 
 
 # ---------------------------------------------------------------------------
@@ -288,10 +288,10 @@ def dynamic_energy_per_op(
     )
 
 
-def dynamic_energy_kwh(
+def dynamic_energy_j(
     ops: float, code: str, node_nm: float, vdd: float, *, mode: str = "pwl"
 ) -> float:
-    return ops * dynamic_energy_per_op(code, node_nm, vdd, mode=mode) / 3.6e6
+    return ops * dynamic_energy_per_op(code, node_nm, vdd, mode=mode)
 
 
 def energy_report(
@@ -304,9 +304,9 @@ def energy_report(
     *,
     mode: str = "pwl",
 ) -> Dict[str, float]:
-    dyn = dynamic_energy_kwh(ops, code, node_nm, vdd, mode=mode)
-    leak = leakage_energy_kwh(vdd, node_nm, temp_c, code, lifetime_h)
-    return {"dynamic_kWh": dyn, "leakage_kWh": leak, "total_kWh": dyn + leak}
+    dyn = dynamic_energy_j(ops, code, node_nm, vdd, mode=mode)
+    leak = leakage_energy_j(vdd, node_nm, temp_c, code, lifetime_h)
+    return {"dynamic_J": dyn, "leakage_J": leak, "total_J": dyn + leak}
 
 
 if __name__ == "__main__":

--- a/esii.py
+++ b/esii.py
@@ -9,6 +9,72 @@ offers utilities for deriving embodied-carbon terms from hardware properties.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Dict, Literal
+
+KWH_PER_J = 3_600_000.0  # 1 kWh = 3.6e6 J
+
+
+@dataclass(frozen=True)
+class ESIIInputs:
+    """Inputs required to compute the ESII metric.
+
+    Parameters
+    ----------
+    fit_base : float
+        Baseline failure rate in FIT (failures / 1e9 hours).
+    fit_ecc : float
+        Failure rate with ECC applied.
+    e_dyn : float
+        Dynamic energy attributable to ECC in Joules.
+    e_leak : float
+        Leakage energy attributable to ECC in Joules.
+    ci_kgco2e_per_kwh : float
+        Grid carbon intensity.
+    embodied_kgco2e : float
+        Embodied carbon from added logic and memory.
+    basis : {"per_gib", "system"}
+        Reliability basis.  Optional metadata for reports.
+    """
+
+    fit_base: float
+    fit_ecc: float
+    e_dyn: float
+    e_leak: float
+    ci_kgco2e_per_kwh: float
+    embodied_kgco2e: float
+    basis: Literal["per_gib", "system"] = "per_gib"
+
+
+def _j_to_kwh(x: float) -> float:
+    return x / KWH_PER_J
+
+
+def compute_esii(inp: ESIIInputs) -> Dict[str, float]:
+    """Return ESII and a compact breakdown.
+
+    The dictionary contains the ESII value along with the individual components
+    contributing to the carbon footprint.
+    """
+
+    e_dyn_kwh = _j_to_kwh(inp.e_dyn)
+    e_leak_kwh = _j_to_kwh(inp.e_leak)
+    operational_kgco2e = inp.ci_kgco2e_per_kwh * (e_dyn_kwh + e_leak_kwh)
+    total_kgco2e = operational_kgco2e + inp.embodied_kgco2e
+
+    delta_fit = max(inp.fit_base - inp.fit_ecc, 0.0)
+    esii = 0.0 if total_kgco2e < 1e-12 else delta_fit / total_kgco2e
+
+    return {
+        "ESII": esii,
+        "delta_FIT": delta_fit,
+        "operational_kgCO2e": operational_kgco2e,
+        "embodied_kgCO2e": inp.embodied_kgco2e,
+        "total_kgCO2e": total_kgco2e,
+        "E_dyn_kWh": e_dyn_kwh,
+        "E_leak_kWh": e_leak_kwh,
+    }
+
 
 def embodied_from_wire_area(area_mm2: float, factor_kg_per_mm2: float) -> float:
     """Return embodied carbon for additional wiring.
@@ -25,51 +91,8 @@ def embodied_from_wire_area(area_mm2: float, factor_kg_per_mm2: float) -> float:
     float
         Equivalent embodied carbon in kilograms of CO2e.
     """
+
     if area_mm2 < 0 or factor_kg_per_mm2 < 0:
         raise ValueError("area and factor must be non-negative")
     return area_mm2 * factor_kg_per_mm2
 
-
-def compute_esii(
-    fit_base: float,
-    fit_ecc: float,
-    E_dyn_kWh: float,
-    E_leak_kWh: float,
-    CI: float,
-    EC_embodied_kg: float,
-) -> float:
-    """Compute the Environmental Sustainability Improvement Index (ESII).
-
-    Parameters
-    ----------
-    fit_base : float
-        Failure rate in FIT (failures per 1e9 hours) for the baseline system.
-    fit_ecc : float
-        Failure rate in FIT when error correction is applied.
-    E_dyn_kWh : float
-        Dynamic energy consumption over the lifetime in kWh.
-    E_leak_kWh : float
-        Leakage energy consumption over the lifetime in kWh.
-    CI : float
-        Carbon intensity in kgCO2e per kWh.
-    EC_embodied_kg : float
-        Embodied carbon of the technique in kgCO2e.
-
-    Returns
-    -------
-    float
-        The ESII value which represents reliability improvement per kgCO2e.
-    """
-    if CI < 0 or E_dyn_kWh < 0 or E_leak_kWh < 0 or EC_embodied_kg < 0:
-        raise ValueError("Energy and carbon terms must be non-negative")
-    if fit_base < fit_ecc:
-        raise ValueError("ECC must not worsen the FIT")
-
-    dynamic = E_dyn_kWh * CI
-    leakage = E_leak_kWh * CI
-    total_carbon = dynamic + leakage + EC_embodied_kg
-    if total_carbon <= 0:
-        raise ValueError("Total carbon must be positive")
-
-    reliability_gain = fit_base - fit_ecc
-    return reliability_gain / total_carbon

--- a/tests/python/test_carbon.py
+++ b/tests/python/test_carbon.py
@@ -2,15 +2,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-from carbon import embodied_kg, operational_kg
+from carbon import embodied_kgco2e, operational_kgco2e
 
 
 def test_operational_sign():
-    assert operational_kg(1.0, 0.0, 0.5) == 0.5
+    assert operational_kgco2e(1.0, 0.0, 0.5) == 0.5
 
 
 def test_embodied_additivity():
-    assert embodied_kg(0.1, 0.2, 1.0, 2.0) == 0.1 * 1.0 + 0.2 * 2.0
+    assert embodied_kgco2e(0.1, 0.2, 1.0, 2.0) == 0.1 * 1.0 + 0.2 * 2.0
 
 
 def test_cli_round_trip():

--- a/tests/python/test_energy.py
+++ b/tests/python/test_energy.py
@@ -26,5 +26,5 @@ def test_energy_cli_json(tmp_path):
     ]
     out = subprocess.check_output(cmd)
     data = json.loads(out)
-    assert "dynamic_kWh" in data
-    assert "leakage_kWh" in data
+    assert "dynamic_J" in data
+    assert "leakage_J" in data

--- a/tests/python/test_energy_model.py
+++ b/tests/python/test_energy_model.py
@@ -71,16 +71,16 @@ def test_vector_api():
 
 
 def test_dynamic_energy_scales_with_ops():
-    e1 = energy_model.dynamic_energy_kwh(1e3, "sec-ded", 28, 0.8)
-    e2 = energy_model.dynamic_energy_kwh(2e3, "sec-ded", 28, 0.8)
+    e1 = energy_model.dynamic_energy_j(1e3, "sec-ded", 28, 0.8)
+    e2 = energy_model.dynamic_energy_j(2e3, "sec-ded", 28, 0.8)
     assert e2 == pytest.approx(2 * e1)
 
 
 def test_leakage_energy_monotonic():
-    low_temp = energy_model.leakage_energy_kwh(0.8, 28, 25, "sec-ded", 1)
-    high_temp = energy_model.leakage_energy_kwh(0.8, 28, 35, "sec-ded", 1)
+    low_temp = energy_model.leakage_energy_j(0.8, 28, 25, "sec-ded", 1)
+    high_temp = energy_model.leakage_energy_j(0.8, 28, 35, "sec-ded", 1)
     assert high_temp > low_temp
 
-    small_area = energy_model.leakage_energy_kwh(0.8, 28, 75, "sec-ded", 1)
-    large_area = energy_model.leakage_energy_kwh(0.8, 28, 75, "taec", 1)
+    small_area = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1)
+    large_area = energy_model.leakage_energy_j(0.8, 28, 75, "taec", 1)
     assert large_area > small_area

--- a/tests/python/test_esii.py
+++ b/tests/python/test_esii.py
@@ -2,16 +2,28 @@ import subprocess
 import sys
 from pathlib import Path
 import math
+import json
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
-from esii import compute_esii, embodied_from_wire_area
+from esii import ESIIInputs, compute_esii, embodied_from_wire_area
 
 
 def test_compute_esii():
-    result = compute_esii(1000, 100, 1.0, 0.5, 0.2, 10)
+    inp = ESIIInputs(
+        fit_base=1000,
+        fit_ecc=100,
+        e_dyn=3_600_000.0,
+        e_leak=1_800_000.0,
+        ci_kgco2e_per_kwh=0.2,
+        embodied_kgco2e=10,
+    )
+    result = compute_esii(inp)
     expected = 900 / 10.3
-    assert math.isclose(result, expected)
+    assert math.isclose(result["ESII"], expected)
 
 
 def test_embodied_from_wire_area():
@@ -20,8 +32,9 @@ def test_embodied_from_wire_area():
         embodied_from_wire_area(-1, 2)
 
 
-def test_cli_esii_outputs_result():
+def test_cli_esii_outputs_result(tmp_path):
     script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    out = tmp_path / "esii.json"
     cmd = [
         sys.executable,
         str(script),
@@ -30,17 +43,100 @@ def test_cli_esii_outputs_result():
         "1000",
         "--fit-ecc",
         "100",
-        "--E-dyn",
+        "--e-dyn-j",
         "1",
-        "--E-leak",
+        "--e-leak-j",
         "0.5",
         "--ci",
         "0.2",
-        "--wire-area-mm2",
-        "5",
-        "--wire-factor-kg-per-mm2",
-        "2",
+        "--embodied-kgco2e",
+        "0.05",
+        "--basis",
+        "per_gib",
+        "--out",
+        str(out),
     ]
-    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    first_line = res.stdout.splitlines()[0]
-    assert first_line == "ESII: 87.379"
+    subprocess.run(cmd, check=True)
+    data = json.load(open(out))
+    inp = ESIIInputs(
+        fit_base=1000,
+        fit_ecc=100,
+        e_dyn=1.0,
+        e_leak=0.5,
+        ci_kgco2e_per_kwh=0.2,
+        embodied_kgco2e=0.05,
+    )
+    expected = compute_esii(inp)
+    assert data["ESII"] == pytest.approx(expected["ESII"])
+    assert data["basis"] == "per_gib"
+
+
+def test_cli_esii_reports(tmp_path):
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    rel = tmp_path / "rel.json"
+    energy = tmp_path / "energy.json"
+    area = tmp_path / "area.json"
+    json.dump(
+        {
+            "basis": "per_gib",
+            "fit": {"base": 300.0, "ecc": 5.0},
+            "mbu": "moderate",
+            "scrub_s": 10,
+            "node_nm": 14,
+            "vdd": 0.8,
+            "tempC": 75,
+        },
+        open(rel, "w"),
+    )
+    json.dump({"dynamic_J": 2088.0, "leakage_J": 972.0}, open(energy, "w"))
+    json.dump({"logic_mm2": 0.1, "macro_mm2": 0.2, "node_nm": 14}, open(area, "w"))
+    out = tmp_path / "esii.json"
+    cmd = [
+        sys.executable,
+        str(script),
+        "esii",
+        "--reliability",
+        str(rel),
+        "--energy",
+        str(energy),
+        "--area",
+        str(area),
+        "--ci",
+        "0.55",
+        "--embodied-override-kgco2e",
+        "none",
+        "--basis",
+        "per_gib",
+        "--out",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+    data = json.load(open(out))
+    inp = ESIIInputs(
+        fit_base=300.0,
+        fit_ecc=5.0,
+        e_dyn=2088.0,
+        e_leak=972.0,
+        ci_kgco2e_per_kwh=0.55,
+        embodied_kgco2e=0.1 * 0.8 + 0.2 * 1.0,
+    )
+    expected = compute_esii(inp)
+    assert data["ESII"] == pytest.approx(expected["ESII"])
+    assert data["inputs"]["fit_base"] == 300.0
+
+
+def test_esii_monotone_ci():
+    a = compute_esii(ESIIInputs(300, 10, 3000, 2000, 0.6, 0.05))
+    b = compute_esii(ESIIInputs(300, 10, 3000, 2000, 0.9, 0.05))
+    assert a["ESII"] > b["ESII"]
+
+
+def test_esii_stronger_ecc():
+    a = compute_esii(ESIIInputs(300, 10, 3000, 2000, 0.6, 0.05))
+    c = compute_esii(ESIIInputs(300, 5, 3000, 2000, 0.6, 0.05))
+    assert c["ESII"] > a["ESII"]
+
+
+def test_esii_zero_carbon_guard():
+    z = compute_esii(ESIIInputs(100, 0, 0.0, 0.0, 0.0, 0.0))
+    assert z["ESII"] == 0.0

--- a/tests/python/test_reliability_report_cli.py
+++ b/tests/python/test_reliability_report_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from ser_model import HazuchaParams, ser_hazucha
+from fit import compute_fit_pre, compute_fit_post, ecc_coverage_factory, fit_system
 
 
 def test_reliability_report_json():
@@ -26,13 +27,36 @@ def test_reliability_report_json():
         "3600",
         "--capacity-gib",
         "1.0",
+        "--basis",
+        "per_gib",
+        "--mbu",
+        "none",
+        "--node-nm",
+        "14",
+        "--vdd",
+        "0.8",
+        "--tempC",
+        "75",
         "--json",
     ]
     res = subprocess.run(cmd, capture_output=True, text=True, check=True)
     data = json.loads(res.stdout)
     hp = HazuchaParams(Qs_fC=0.25, flux_rel=1.0, area_um2=0.08)
-    expected = ser_hazucha(1.2, hp)
-    assert data["fit_bit"] == pytest.approx(expected)
+    fit_bit = ser_hazucha(1.2, hp)
+    fit_pre = compute_fit_pre(64, fit_bit, {})
+    coverage = ecc_coverage_factory("SEC-DED")
+    fit_post = compute_fit_post(64, fit_bit, {}, coverage, 3600)
+    expected_base = fit_system(1.0, fit_pre)
+    expected_ecc = fit_system(1.0, fit_post)
+    base_nom = (
+        expected_base.nominal if hasattr(expected_base, "nominal") else expected_base
+    )
+    ecc_nom = (
+        expected_ecc.nominal if hasattr(expected_ecc, "nominal") else expected_ecc
+    )
+    assert data["fit"]["base"] == pytest.approx(base_nom)
+    assert data["fit"]["ecc"] == pytest.approx(ecc_nom)
+    assert data["basis"] == "per_gib"
     assert "fit_bit" in res.stderr
 
 
@@ -51,6 +75,16 @@ def test_reliability_report_text():
         "0.08",
         "--flux-rel",
         "1.0",
+        "--scrub-interval",
+        "3600",
+        "--capacity-gib",
+        "1.0",
+        "--node-nm",
+        "14",
+        "--vdd",
+        "0.8",
+        "--tempC",
+        "75",
     ]
     res = subprocess.run(cmd, capture_output=True, text=True, check=True)
     lines = {line.split()[0] for line in res.stdout.strip().splitlines()}


### PR DESCRIPTION
## Summary
- enforce Joule-based energy inputs and explicit kgCO2e carbon labels
- update CLI and energy model to emit Joule reports and compute ESII without unit ambiguity
- add ESII regression tests for carbon intensity, ECC strength, and zero-carbon guard

## Testing
- `pytest tests/python/test_carbon.py -q`
- `pytest tests/python/test_energy.py -q`
- `pytest tests/python/test_energy_model.py -q`
- `pytest tests/python/test_reliability_report_cli.py::test_reliability_report_json -q`
- `pytest tests/python/test_reliability_report_cli.py::test_reliability_report_text -q`
- `pytest tests/python/test_esii.py -q`
- `pytest tests/python -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5608acb4832e92385e11952c0237