### PR TITLE
Use calibrated gate energies in C++ simulator

### DIFF
--- a/Hamming64bit128Gb.cpp
+++ b/Hamming64bit128Gb.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <cstdlib>
 #include "ParityCheckMatrix.hpp"
+#include "gate_energy.hpp"
 
 class HammingCodeSECDED {
 public:
@@ -344,9 +345,9 @@ public:
                       << (100.0 * counters["data_corruption_prevented"] / total_errors) << "%" << std::endl;
         }
 
-        // Energy estimate based on typical CMOS gate costs
-        const double ENERGY_PER_XOR = 2e-12; // 2 pJ per XOR gate
-        const double ENERGY_PER_AND = 1e-12; // 1 pJ per AND gate
+        // Energy estimate based on calibration data
+        const double ENERGY_PER_XOR = gate_energy(28, 0.8, "xor");
+        const double ENERGY_PER_AND = gate_energy(28, 0.8, "and");
 
         uint64_t detected_errors = counters["single_errors_corrected"] +
                                    counters["double_errors_detected"] +

--- a/docs/EnergyModel.md
+++ b/docs/EnergyModel.md
@@ -2,14 +2,13 @@
 
 This module provides a tiny energy estimation for each read operation in the
 simulators. It multiplies the number of XOR and AND gate evaluations by
-constant energy costs.
+technology-aware energy costs loaded from `tech_calib.json`.
 
-## Constants
+## Calibration
 
-- `ENERGY_PER_XOR` – energy in joules used by a single XOR gate. The default
-  value is `2e-12` J.
-- `ENERGY_PER_AND` – energy in joules used by a single AND gate. The default
-  value is `1e-12` J.
+`tech_calib.json` maps process node and voltage to per-gate energy figures for
+XOR and AND operations. The loader performs piecewise linear interpolation over
+this table so the estimate reflects the chosen technology and supply voltage.
 
 ## Running the script
 
@@ -42,7 +41,7 @@ coding schemes during reads without running the full simulators.
 
 ## Typical Values from Literature
 
-The default constants correspond to energy measurements published for
-28&nbsp;nm CMOS processes, where an XOR gate consumes roughly 2&nbsp;pJ per
-operation and an AND gate about 1&nbsp;pJ. These figures provide a
-reasonable baseline when evaluating the simulators on common hardware.
+The calibration data includes energy measurements published for 28&nbsp;nm CMOS
+processes, where an XOR gate consumes roughly 2&nbsp;pJ per operation and an AND
+gate about 1&nbsp;pJ. These figures provide a reasonable baseline when evaluating
+the simulators on common hardware.

--- a/gate_energy.hpp
+++ b/gate_energy.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <algorithm>
+#include <fstream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+inline double interpolate(double x, const std::vector<double>& xs, const std::vector<double>& ys) {
+    if (xs.empty() || ys.empty() || xs.size() != ys.size()) {
+        throw std::runtime_error("Invalid interpolation data");
+    }
+    if (x <= xs.front()) return ys.front();
+    if (x >= xs.back()) return ys.back();
+    auto upper = std::upper_bound(xs.begin(), xs.end(), x);
+    size_t i = std::distance(xs.begin(), upper) - 1;
+    double x0 = xs[i], x1 = xs[i + 1];
+    double y0 = ys[i], y1 = ys[i + 1];
+    return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+}
+
+inline const nlohmann::json& load_calib(const std::string& path = "tech_calib.json") {
+    static nlohmann::json calib;
+    static bool loaded = false;
+    if (!loaded) {
+        std::ifstream f(path);
+        if (!f) {
+            throw std::runtime_error("Unable to open calibration file: " + path);
+        }
+        f >> calib;
+        loaded = true;
+    }
+    return calib;
+}
+
+inline double gate_energy(int node_nm, double vdd, const std::string& gate,
+                          const std::string& path = "tech_calib.json") {
+    const auto& calib = load_calib(path);
+
+    // Collect available nodes
+    std::vector<int> nodes;
+    nodes.reserve(calib.size());
+    for (auto it = calib.begin(); it != calib.end(); ++it) {
+        nodes.push_back(std::stoi(it.key()));
+    }
+    std::sort(nodes.begin(), nodes.end());
+
+    // For each node, interpolate energy over VDD
+    std::vector<double> energies_at_nodes;
+    energies_at_nodes.reserve(nodes.size());
+    for (int node : nodes) {
+        const auto& node_table = calib.at(std::to_string(node));
+        std::vector<double> volts;
+        std::vector<double> vals;
+        volts.reserve(node_table.size());
+        vals.reserve(node_table.size());
+        for (auto it = node_table.begin(); it != node_table.end(); ++it) {
+            double v = std::stod(it.key());
+            volts.push_back(v);
+            vals.push_back(it.value()["gates"].at(gate).get<double>());
+        }
+        // sort by voltage
+        std::vector<size_t> idx(volts.size());
+        std::iota(idx.begin(), idx.end(), 0);
+        std::sort(idx.begin(), idx.end(), [&](size_t a, size_t b) { return volts[a] < volts[b]; });
+        std::vector<double> v_sorted, val_sorted;
+        v_sorted.reserve(idx.size());
+        val_sorted.reserve(idx.size());
+        for (size_t i : idx) {
+            v_sorted.push_back(volts[i]);
+            val_sorted.push_back(vals[i]);
+        }
+        double v_clamped = std::min(std::max(vdd, v_sorted.front()), v_sorted.back());
+        energies_at_nodes.push_back(interpolate(v_clamped, v_sorted, val_sorted));
+    }
+
+    // Interpolate across nodes
+    std::vector<double> node_d(nodes.begin(), nodes.end());
+    double n_clamped = std::min(std::max(static_cast<double>(node_nm), node_d.front()), node_d.back());
+    return interpolate(n_clamped, node_d, energies_at_nodes);
+}
+


### PR DESCRIPTION
## Summary
- load XOR and AND gate energies from `tech_calib.json` with a new C++ helper
- compute Hamming64 energy using calibrated values instead of fixed constants
- document calibration-driven energy model

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a1bf67cbc0832e97979e84fd866339