### PR TITLE
docs: mention nlohmann json dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(ECCsim LANGUAGES CXX)
 
+find_package(nlohmann_json 3 REQUIRED)
+
 include(FetchContent)
 FetchContent_Declare(
     googletest
@@ -11,6 +13,7 @@ FetchContent_MakeAvailable(googletest)
 
 add_library(ecc_core INTERFACE)
 target_include_directories(ecc_core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(ecc_core INTERFACE nlohmann_json::nlohmann_json)
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ See [docs/TestSummary.md](docs/TestSummary.md) for an overview of the simulator 
 
 ECC for SRAM, studying the impact of ECC architectures on sustainability
 
+## Prerequisites
+
+The C++ components depend on the header-only [nlohmann/json](https://github.com/nlohmann/json) library. On Debian-based systems it can be installed via:
+
+```bash
+sudo apt-get install nlohmann-json3-dev
+```
+
 Running the simulators now produces several structured result files in the
 repository root:
 


### PR DESCRIPTION
## Summary
- document nlohmann/json prerequisite in README
- require and link nlohmann_json in CMake for build-time checks

## Testing
- `cmake --build build && ctest --output-on-failure`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c1294400832ebc6128b1d772d582