### PR TITLE
Precompute parity-check matrices for Hamming simulators

### DIFF
--- a/Hamming64bit128Gb.cpp
+++ b/Hamming64bit128Gb.cpp
@@ -23,9 +23,26 @@ public:
     
 private:
     // Parity bit positions (powers of 2): 1, 2, 4, 8, 16, 32, 64
-    std::vector<int> parity_positions = {1, 2, 4, 8, 16, 32, 64};
-    
+    const std::vector<int> parity_positions = {1, 2, 4, 8, 16, 32, 64};
+    ParityCheckMatrix pcm;
+
 public:
+    HammingCodeSECDED() {
+        for (int parity_bit : parity_positions) {
+            std::array<uint64_t,2> row{0,0};
+            for (int pos = 1; pos <= TOTAL_BITS - 1; ++pos) {
+                if (pos & parity_bit) {
+                    int idx = pos - 1;
+                    if (idx < 64)
+                        row[0] |= (1ULL << idx);
+                    else
+                        row[1] |= (1ULL << (idx-64));
+                }
+            }
+            pcm.rows.push_back(row);
+        }
+    }
+
     struct CodeWord {
         uint64_t data_low;   // Lower 64 bits
         uint16_t data_high;  // Upper 8 bits (72-64=8 bits needed)
@@ -93,17 +110,17 @@ public:
     };
     
     // Check if position is a parity bit position
-    bool isParityPosition(int pos) {
+    bool isParityPosition(int pos) const {
         return (pos & (pos - 1)) == 0 && pos <= 64;  // Check if pos is power of 2 <= 64
     }
     
     // Check if position is overall parity position
-    bool isOverallParityPosition(int pos) {
+    bool isOverallParityPosition(int pos) const {
         return pos == TOTAL_BITS;  // Position 72
     }
     
     // Get data bit positions (non-parity, non-overall-parity positions)
-    std::vector<int> getDataPositions() {
+    std::vector<int> getDataPositions() const {
         std::vector<int> positions;
         for (int i = 1; i <= TOTAL_BITS; i++) {
             if (!isParityPosition(i) && !isOverallParityPosition(i)) {
@@ -114,7 +131,7 @@ public:
     }
     
     // Encode 64-bit data into 72-bit SEC-DED Hamming codeword
-    CodeWord encode(uint64_t data) {
+    CodeWord encode(uint64_t data) const {
         CodeWord codeword;
         
         // Place data bits in non-parity positions
@@ -153,27 +170,11 @@ public:
     }
     
     // Decode SEC-DED Hamming codeword with enhanced error detection
-    DecodingResult decode(CodeWord received) {
+    DecodingResult decode(CodeWord received) const {
         DecodingResult result;
         result.syndrome = 0;
         result.error_position = 0;
         result.data_corrected = false;
-        
-        // Build parity check matrix once per decode
-        ParityCheckMatrix pcm;
-        for (int parity_bit : parity_positions) {
-            std::array<uint64_t,2> row{0,0};
-            for (int pos = 1; pos <= TOTAL_BITS - 1; ++pos) {
-                if (pos & parity_bit) {
-                    int idx = pos - 1;
-                    if (idx < 64)
-                        row[0] |= (1ULL << idx);
-                    else
-                        row[1] |= (1ULL << (idx-64));
-                }
-            }
-            pcm.rows.push_back(row);
-        }
 
         BitVector cwVec;
         for (int pos = 1; pos <= TOTAL_BITS - 1; ++pos) {


### PR DESCRIPTION
## Summary
- Precompute parity-check matrices in Hamming simulator constructors and reuse them during decoding.
- Mark decoding methods `const` to allow safe concurrent use.
- Remove per-decode matrix construction overhead.

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c22d25f0832eaec9838d3d15cfc3