### PR TITLE
Fix nlohmann header usage

### DIFF
--- a/gate_energy.hpp
+++ b/gate_energy.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
 inline double interpolate(double x, const std::vector<double>& xs, const std::vector<double>& ys) {
     if (xs.empty() || ys.empty() || xs.size() != ys.size()) {


### PR DESCRIPTION
## Summary
- include vendored nlohmann JSON header directly in gate_energy.hpp to avoid mismatched system versions

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a482bee3f8832eb2c0d5e188ac9804