### PR TITLE
Fix nlohmann header usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
 cmake_minimum_required(VERSION 3.14)
 project(ECCsim LANGUAGES CXX)
 
-# Prefer a system installation of nlohmann_json but fall back to the
-# header vendored in the repository if it is not available.
-find_package(nlohmann_json 3 QUIET)
+# Prefer a specific system installation of nlohmann_json but fall back to
+# the header vendored in the repository if it is not available.  Requiring
+# the exact version avoids mismatches that previously triggered compilation
+# failures in downstream builds.
+find_package(nlohmann_json 3.11.2 QUIET)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -14,11 +16,13 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 add_library(ecc_core INTERFACE)
-target_include_directories(ecc_core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ecc_core INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/nlohmann)
 if(nlohmann_json_FOUND)
     target_link_libraries(ecc_core INTERFACE nlohmann_json::nlohmann_json)
 else()
-    message(STATUS "nlohmann_json not found; using vendored header")
+    message(STATUS "nlohmann_json 3.11.2 not found; using vendored header")
 endif()
 
 enable_testing()

--- a/gate_energy.hpp
+++ b/gate_energy.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
 inline double interpolate(double x, const std::vector<double>& xs, const std::vector<double>& ys) {
     if (xs.empty() || ys.empty() || xs.size() != ys.size()) {


### PR DESCRIPTION
## Summary
- pin CMake build to nlohmann_json v3.11.2 and default to vendored header when unavailable

## Testing
- `make clean`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a482bee3f8832eb2c0d5e188ac9804