### PR TITLE
Add ESII normalization and expose NESII in ECC selector

### DIFF
--- a/tests/python/test_selector_multiobj.py
+++ b/tests/python/test_selector_multiobj.py
@@ -41,3 +41,10 @@ def test_scenario_shift_mbu():
 
     assert codes_light == {"sec-ded-64"}
     assert {"sec-daec-64", "taec-64"}.issubset(codes_heavy)
+
+
+def test_nesii_normalisation():
+    res = select(["sec-ded-64", "sec-daec-64", "taec-64"], **_default_params())
+    assert res["nesii_p5"] <= res["nesii_p95"]
+    for rec in res["pareto"]:
+        assert 0.0 <= rec["NESII"] <= 100.0


### PR DESCRIPTION
## Summary
- add `normalise_esii` helper with winsorized 5–95% scaling
- compute and return normalized ESII (NESII) in `ecc_selector.select`
- test NESII range and percentile metadata

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a542735b8c832eab022061d9d60b0b