### PR TITLE
Add NESII normalization metadata and epsilon-based Pareto filtering

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -284,14 +284,19 @@ def main() -> None:
 
             fieldnames = [
                 "code",
+                "scrub_s",
                 "FIT",
-                "ESII",
                 "carbon_kg",
-                "E_dyn_kWh",
-                "E_leak_kWh",
                 "latency_ns",
+                "ESII",
+                "NESII",
+                "p5",
+                "p95",
+                "N_scale",
                 "area_logic_mm2",
                 "area_macro_mm2",
+                "E_dyn_kWh",
+                "E_leak_kWh",
                 "notes",
             ]
             with open(args.report, "w", newline="") as fh:

--- a/tests/python/test_nesii.py
+++ b/tests/python/test_nesii.py
@@ -1,0 +1,16 @@
+import numpy as np
+from esii import normalise_esii
+
+
+def test_nesii_monotonic():
+    esii_vals = [1.0, 2.0, 3.0, 4.0]
+    scores, p5, p95 = normalise_esii(esii_vals)
+    assert np.argsort(scores).tolist() == np.argsort(esii_vals).tolist()
+
+
+def test_nesii_invariance_scaling():
+    esii_vals = [1.0, 2.0, 3.0]
+    scores1, _, _ = normalise_esii(esii_vals)
+    scaled = [v * 0.5 for v in esii_vals]
+    scores2, _, _ = normalise_esii(scaled)
+    assert np.argsort(scores1).tolist() == np.argsort(scores2).tolist()

--- a/tests/python/test_selector_multiobj.py
+++ b/tests/python/test_selector_multiobj.py
@@ -45,6 +45,10 @@ def test_scenario_shift_mbu():
 
 def test_nesii_normalisation():
     res = select(["sec-ded-64", "sec-daec-64", "taec-64"], **_default_params())
-    assert res["nesii_p5"] <= res["nesii_p95"]
+    norm = res["normalization"]
+    assert norm["p5"] <= norm["p95"]
     for rec in res["pareto"]:
         assert 0.0 <= rec["NESII"] <= 100.0
+        assert rec["p5"] == norm["p5"]
+        assert rec["p95"] == norm["p95"]
+        assert rec["N_scale"] == norm["N"]


### PR DESCRIPTION
## Summary
- compute Pareto front with ε-dominance on normalized axes to avoid float jitter
- record NESII normalization metadata and per-record p5/p95/N and scrub interval
- extend CLI report to include NESII and normalization fields; add monotonicity and invariance tests

## Testing
- `pytest`
- `python eccsim.py select --codes sec-ded-64,sec-daec-64,taec-64 --node 14 --vdd 0.8 --temp 75 --mbu heavy --scrub-s 10 --capacity-gib 128 --ci 0.55 --bitcell-um2 0.040 --report /tmp/pareto.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a5459cc940832e80f519d6ec3c0002