### PR TITLE
Include scrub energy in carbon calculations

### DIFF
--- a/tests/python/test_scrub_energy.py
+++ b/tests/python/test_scrub_energy.py
@@ -1,0 +1,26 @@
+import math
+
+from ecc_selector import select
+from energy_model import estimate_energy
+
+
+def test_scrub_energy_included():
+    params = {
+        "node": 14,
+        "vdd": 0.8,
+        "temp": 75.0,
+        "capacity_gib": 1.0,
+        "ci": 0.5,
+        "bitcell_um2": 0.040,
+        "lifetime_h": 1.0,
+    }
+    res = select(["sec-ded-64"], scrub_s=1.0, **params)
+    rec = res["pareto"][0]
+
+    e_per_read = estimate_energy(8, 0, node_nm=params["node"], vdd=params["vdd"])
+    words = params["capacity_gib"] * (2**30 * 8) / 64
+    expected = (params["lifetime_h"] * 3600 / 1.0) * words * e_per_read / 3_600_000.0
+
+    assert math.isclose(rec["E_dyn_kWh"], expected, rel_tol=1e-9)
+    assert rec["includes_scrub_energy"] is True
+    assert res["includes_scrub_energy"] is True


### PR DESCRIPTION
## Summary
- incorporate lifetime scrubbing reads into dynamic energy and carbon
- surface `includes_scrub_energy` flag in selection outputs
- test scrub energy accounting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a556340434832e831564424f27675c