### PR TITLE
Drop CMake requirement for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build outputs
 *.out
 *.o
+*.d
 BCHvsHamming
 Hamming32bit1Gb
 Hamming64bit128Gb
@@ -14,6 +15,11 @@ decoding_results.json
 ecc_stats.csv
 ecc_stats.json
 secdaec_energy.csv
+tests/unit/SecDaec64_test
+
+# Python bytecode caches
+__pycache__/
+*/__pycache__/
 
 # macOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -30,16 +30,18 @@ SATDemo: SAT.o
 	$(CXX) $(CXXFLAGS) $< -o $@
 
 clean:
-	rm -f $(BINARIES) $(OBJ) $(DEP)
+	rm -f $(BINARIES) $(OBJ) $(DEP) tests/unit/SecDaec64_test tests/unit/SecDaec64_test.d
 
 -include $(DEP)
 
 .PHONY: test clean gtest
 
-gtest:
-	cmake -S . -B build
-	cmake --build build
-	cd build && ctest --output-on-failure
+# Build and run C++ unit tests without relying on CMake or external gtest
+gtest: tests/unit/SecDaec64_test
+	./tests/unit/SecDaec64_test
+
+tests/unit/SecDaec64_test: tests/unit/SecDaec64_test.cpp SecDaec64.hpp BitVector.hpp ParityCheckMatrix.hpp telemetry.hpp
+	$(CXX) $(CXXFLAGS) $< -o $@
 
 test: all gtest
 	./tests/smoke_test.sh

--- a/tests/unit/SecDaec64_test.cpp
+++ b/tests/unit/SecDaec64_test.cpp
@@ -1,15 +1,20 @@
 #include "SecDaec64.hpp"
-#include <gtest/gtest.h>
+#include <cassert>
+#include <iostream>
 
-TEST(SecDaec64, AdjacentDataPairErrors) {
+int main() {
     SecDaec64 codec;
     auto clean = codec.encode(0x12345678abcdefULL);
     auto dataPos = codec.getDataPositions();
-    for(size_t i=0; i+1<dataPos.size(); ++i) {
+    for (size_t i = 0; i + 1 < dataPos.size(); ++i) {
         SecDaec64::CodeWord cw = clean;
         cw.bits.set(dataPos[i], !cw.bits.get(dataPos[i]));
-        cw.bits.set(dataPos[i+1], !cw.bits.get(dataPos[i+1]));
+        cw.bits.set(dataPos[i + 1], !cw.bits.get(dataPos[i + 1]));
         auto res = codec.decode(cw);
-        ASSERT_TRUE(res.detected) << "Decoder failed to detect corruption at pair index " << i;
+        if (!res.detected) {
+            std::cerr << "Decoder failed to detect corruption at pair index " << i << std::endl;
+            return 1;
+        }
     }
+    return 0;
 }


### PR DESCRIPTION
## Summary
- build C++ unit test directly with g++, avoiding external CMake and googletest dependencies
- replace gtest-based SecDaec64 test with simple assertion program
- ignore generated dependency files, test binary, and Python cache directories

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a55cc053a4832ea514d95e29410aa8