### PR TITLE
Fix Makefile clean target for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,14 @@ Hamming64bit128Gb: Hamming64bit128Gb.o src/energy_loader.o
 SATDemo: SAT.o
 	$(CXX) $(CXXFLAGS) $< -o $@
 
+ifeq ($(OS),Windows_NT)
+RM := cmd /C del /Q
+else
+RM := rm -f
+endif
+
 clean:
-	rm -f $(BINARIES) $(OBJ) $(DEP) tests/unit/SecDaec64_test tests/unit/SecDaec64_test.d
+	$(RM) $(BINARIES) $(OBJ) $(DEP) tests/unit/SecDaec64_test tests/unit/SecDaec64_test.d
 
 -include $(DEP)
 


### PR DESCRIPTION
## Summary
- Use platform-aware `RM` in Makefile so `make clean` works on Windows and Unix-like systems

## Testing
- `make clean`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a87c3727a8832eab8c7488d89b604f