### PR TITLE
Add Goodness Score metric

### DIFF
--- a/gs.py
+++ b/gs.py
@@ -1,0 +1,101 @@
+"""Goodness Score (GS) metric.
+
+The GS aggregates reliability, carbon efficiency and latency
+friendliness into a single bounded index on [0, 100].  The
+three sub-scores are mapped to [0, 1] via simple saturation
+transforms before combining them using a weighted harmonic mean.
+
+The default weights ``(wR, wC, wL) = (0.6, 0.3, 0.1)`` reflect the
+primacy of reliability in SRAM contexts.  Each sub-score is
+returned alongside the raw metrics for transparency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class GSInputs:
+    """Inputs required to compute the GS metric.
+
+    Parameters
+    ----------
+    fit_base : float
+        Baseline system FIT.
+    fit_ecc : float
+        System FIT with ECC applied.
+    carbon_kg : float
+        Total carbon footprint in kilograms of CO2e.
+    latency_ns : float
+        Decode latency in nanoseconds.
+    """
+
+    fit_base: float
+    fit_ecc: float
+    carbon_kg: float
+    latency_ns: float
+
+
+# Placeholder scale parameters for the saturation functions
+_SR_SCALE = 0.05
+_SC_SCALE = 1.0
+_SL_SCALE = 10.0
+
+
+def _sat_improvement(x: float, k: float) -> float:
+    """Saturating transform for beneficial quantities."""
+    return x / (x + k)
+
+
+def _sat_cost(x: float, k: float) -> float:
+    """Saturating transform for cost-like quantities (lower is better)."""
+    return 1.0 / (1.0 + x / k)
+
+
+def compute_gs(
+    inp: GSInputs,
+    *,
+    weights: Tuple[float, float, float] = (0.6, 0.3, 0.1),
+    sr_scale: float = _SR_SCALE,
+    sc_scale: float = _SC_SCALE,
+    sl_scale: float = _SL_SCALE,
+) -> Dict[str, float]:
+    """Return GS and individual sub-scores.
+
+    The function applies saturating transforms to each raw metric and then
+    aggregates the resulting sub-scores via a weighted harmonic mean.  The
+    final GS is scaled to lie within ``[0, 100]``.
+    """
+
+    fit_base = max(inp.fit_base, 0.0)
+    fit_ecc = max(inp.fit_ecc, 0.0)
+    carbon = max(inp.carbon_kg, 0.0)
+    latency = max(inp.latency_ns, 0.0)
+
+    delta_fit = max(fit_base - fit_ecc, 0.0)
+    rel_gain = 0.0 if fit_base <= 0 else delta_fit / fit_base
+
+    sr = _sat_improvement(rel_gain, sr_scale)
+    sc = _sat_cost(carbon, sc_scale)
+    sl = _sat_cost(latency, sl_scale)
+
+    # Weighted harmonic mean; clamp sub-scores to avoid division by zero
+    wR, wC, wL = weights
+    eps = 1e-9
+    denom = wR / max(sr, eps) + wC / max(sc, eps) + wL / max(sl, eps)
+    gs = (wR + wC + wL) / denom * 100.0
+
+    return {
+        "GS": gs,
+        "Sr": sr,
+        "Sc": sc,
+        "Sl": sl,
+        "delta_FIT": delta_fit,
+        "total_kgCO2e": carbon,
+        "latency_ns": latency,
+    }
+
+
+__all__ = ["GSInputs", "compute_gs"]

--- a/tests/python/test_gs.py
+++ b/tests/python/test_gs.py
@@ -1,0 +1,43 @@
+import pytest
+from gs import GSInputs, compute_gs
+
+import pytest
+
+from gs import GSInputs, compute_gs
+
+
+def _manual_gs(fit_base, fit_ecc, carbon, latency):
+    sr_raw = max(fit_base - fit_ecc, 0.0) / fit_base
+    sr = sr_raw / (sr_raw + 0.05)
+    sc = 1.0 / (1.0 + carbon / 1.0)
+    sl = 1.0 / (1.0 + latency / 10.0)
+    denom = 0.6 / sr + 0.3 / sc + 0.1 / sl
+    return {
+        "Sr": sr,
+        "Sc": sc,
+        "Sl": sl,
+        "GS": 100.0 * 1.0 / denom,
+    }
+
+
+def test_compute_gs_basic():
+    inp = GSInputs(fit_base=1000, fit_ecc=100, carbon_kg=10.0, latency_ns=20.0)
+    res = compute_gs(inp)
+    exp = _manual_gs(1000, 100, 10.0, 20.0)
+    assert res["Sr"] == pytest.approx(exp["Sr"])
+    assert res["Sc"] == pytest.approx(exp["Sc"])
+    assert res["Sl"] == pytest.approx(exp["Sl"])
+    assert res["GS"] == pytest.approx(exp["GS"])
+    assert 0.0 <= res["GS"] <= 100.0
+
+
+def test_gs_monotone_reliability():
+    inp_a = GSInputs(fit_base=1000, fit_ecc=500, carbon_kg=5.0, latency_ns=10.0)
+    inp_b = GSInputs(fit_base=1000, fit_ecc=100, carbon_kg=5.0, latency_ns=10.0)
+    assert compute_gs(inp_b)["GS"] > compute_gs(inp_a)["GS"]
+
+
+def test_gs_extreme_costs():
+    inp = GSInputs(fit_base=100, fit_ecc=10, carbon_kg=1e6, latency_ns=1e6)
+    res = compute_gs(inp)
+    assert res["GS"] < 1.0


### PR DESCRIPTION
## Summary
- add `compute_gs` and `GSInputs` for a Goodness Score combining reliability gain, carbon efficiency, and latency friendliness
- expose saturation transforms and weighted harmonic mean with default weights (0.6, 0.3, 0.1)
- include unit tests verifying computation, monotonicity, and bounds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8846c46e0832eacf2a386d36af930