### PR TITLE
feat: export ECC candidate set

### DIFF
--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -491,12 +491,16 @@ def select(
             lifetime_h=float(kwargs.get("lifetime_h", float("nan"))),
         )
 
+        violations = []
         lat_max = constraints.get("latency_ns_max")
         if lat_max is not None and rec["latency_ns"] > lat_max:
-            continue
+            violations.append("latency_ns_max")
         carbon_max = constraints.get("carbon_kg_max")
         if carbon_max is not None and rec["carbon_kg"] > carbon_max:
+            violations.append("carbon_kg_max")
+        if violations:
             continue
+        rec["violations"] = violations
 
         recs.append(rec)
 
@@ -519,6 +523,7 @@ def select(
             "pareto": [],
             "normalization": norm_meta,
             "candidates": list(codes),
+            "candidate_records": [],
             "scenario_hash": scenario_hash,
         }
 
@@ -671,6 +676,7 @@ def select(
         "pareto": f1,
         "normalization": norm_meta,
         "candidates": list(codes),
+        "candidate_records": recs,
         "scenario_hash": scenario_hash,
         "includes_scrub_energy": True,
         "nsga2": nsga_meta,

--- a/tests/python/test_emit_candidates.py
+++ b/tests/python/test_emit_candidates.py
@@ -1,0 +1,60 @@
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_emit_candidates(tmp_path):
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cand = tmp_path / "cand.csv"
+    pareto = tmp_path / "pareto.csv"
+    cmd = [
+        sys.executable,
+        str(script),
+        "select",
+        "--codes",
+        "sec-ded-64,sec-daec-64,taec-64",
+        "--constraints",
+        "latency_ns_max=1.5",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--scrub-s",
+        "10",
+        "--capacity-gib",
+        "8",
+        "--ci",
+        "0.55",
+        "--bitcell-um2",
+        "0.040",
+        "--emit-candidates",
+        str(cand),
+        "--report",
+        str(pareto),
+    ]
+    subprocess.run(cmd, check=True, text=True)
+    assert cand.exists()
+    assert pareto.exists()
+
+    with cand.open() as fh:
+        cand_rows = list(csv.DictReader(fh))
+    with pareto.open() as fh:
+        pareto_rows = list(csv.DictReader(fh))
+
+    for row in cand_rows:
+        assert float(row["latency_ns"]) <= 1.5 + 1e-9
+        assert json.loads(row["violations"]) == []
+
+    cand_codes = {r["code"] for r in cand_rows}
+    pareto_codes = {r["code"] for r in pareto_rows}
+    assert pareto_codes.issubset(cand_codes)
+
+    cand_map = {r["code"]: r for r in cand_rows}
+    for p in pareto_rows:
+        c = cand_map[p["code"]]
+        for key in ("FIT", "carbon_kg", "latency_ns"):
+            assert abs(float(c[key]) - float(p[key])) <= 1e-8 + 1e-12


### PR DESCRIPTION
## Summary
- add `--emit-candidates` to `eccsim select` to write pre-Pareto candidate metrics
- expose candidate records and constraint violations from `ecc_selector.select`
- test that candidate dump satisfies constraints and contains the Pareto frontier

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa9a1df5a0832eac9b1338350a468f