### PR TITLE
Add feasible surface analysis with CLI integration

### DIFF
--- a/analysis/surface.py
+++ b/analysis/surface.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Feasible surface analysis utilities."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+import pandas as pd
+
+from ecc_selector import _pareto_front
+
+import subprocess
+import hashlib
+
+
+def _git_hash() -> str:
+    """Return the current git commit hash or ``unknown`` if unavailable."""
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return "unknown"
+
+
+def _file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+@dataclass
+class SurfaceResult:
+    df: pd.DataFrame
+    frontier_codes: set[str]
+    git: str
+    tech_calib: str
+    scenario_hash: str
+
+
+def analyze_surface(
+    cand_csv: Path, out_csv: Path, plot: Optional[Path] = None
+) -> SurfaceResult:
+    """Classify candidate points and optionally plot the feasible surface."""
+
+    df = pd.read_csv(cand_csv)
+
+    # Identify Pareto frontier
+    recs = df[["code", "FIT", "carbon_kg", "latency_ns"]].to_dict("records")
+    frontier = {r["code"] for r in _pareto_front(recs)}
+    df["frontier"] = df["code"].isin(frontier)
+
+    # NESII bounds check
+    if "NESII" in df.columns:
+        if not df["NESII"].between(0.0, 100.0, inclusive="both").all():
+            raise ValueError("NESII outside [0,100]")
+
+    # provenance
+    repo_path = Path(__file__).resolve().parents[1]
+    git = _git_hash()
+    tech = _file_hash(repo_path / "tech_calib.json")
+    df["git"] = git
+    df["tech_calib"] = tech
+    scen_hash = str(df.get("scenario_hash").iloc[0]) if "scenario_hash" in df else ""
+
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_csv, index=False)
+
+    if plot is not None:
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            plot.write_text("matplotlib not installed")
+        else:
+            dominated = df[~df["frontier"]]
+            front = df[df["frontier"]]
+            plt.figure()
+            if not dominated.empty:
+                plt.scatter(
+                    dominated["carbon_kg"],
+                    dominated["FIT"],
+                    c=dominated["latency_ns"],
+                    cmap="viridis",
+                    alpha=0.3,
+                    label="dominated",
+                )
+            if not front.empty:
+                plt.scatter(
+                    front["carbon_kg"],
+                    front["FIT"],
+                    c=front["latency_ns"],
+                    cmap="viridis",
+                    edgecolors="black",
+                    label="frontier",
+                )
+            plt.xlabel("carbon_kg")
+            plt.ylabel("FIT")
+            plt.title("Feasible surface")
+            plt.legend()
+            plt.tight_layout()
+            plt.savefig(plot)
+            plt.close()
+
+    return SurfaceResult(df=df, frontier_codes=frontier, git=git, tech_calib=tech, scenario_hash=scen_hash)
+
+
+__all__ = ["analyze_surface", "SurfaceResult"]

--- a/eccsim.py
+++ b/eccsim.py
@@ -216,6 +216,15 @@ def main() -> None:
     arch_parser.add_argument("--from", dest="from_csv", type=Path, required=True)
     arch_parser.add_argument("--out", type=Path, required=True)
 
+    surface_parser = analyze_sub.add_parser(
+        "surface", help="Analyse feasible surface from candidates"
+    )
+    surface_parser.add_argument(
+        "--from-candidates", dest="cand_csv", type=Path, required=True
+    )
+    surface_parser.add_argument("--out-csv", dest="out_csv", type=Path, required=True)
+    surface_parser.add_argument("--plot", type=Path, default=None)
+
     reliability_parser = sub.add_parser(
         "reliability", help="Reliability calculations"
     )
@@ -273,6 +282,10 @@ def main() -> None:
             from analysis.archetype import classify_archetypes
 
             classify_archetypes(args.from_csv, args.out)
+        elif args.analyze_command == "surface":
+            from analysis.surface import analyze_surface
+
+            analyze_surface(args.cand_csv, args.out_csv, args.plot)
         else:
             parser.error("analyze subcommand required")
         return

--- a/tests/python/test_surface_analysis.py
+++ b/tests/python/test_surface_analysis.py
@@ -1,0 +1,72 @@
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_surface_analysis(tmp_path: Path) -> None:
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cand = tmp_path / "cand.csv"
+    pareto = tmp_path / "pareto.csv"
+    cmd = [
+        sys.executable,
+        str(script),
+        "select",
+        "--codes",
+        "sec-ded-64,sec-daec-64,taec-64",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--scrub-s",
+        "10",
+        "--capacity-gib",
+        "8",
+        "--ci",
+        "0.55",
+        "--bitcell-um2",
+        "0.040",
+        "--emit-candidates",
+        str(cand),
+        "--report",
+        str(pareto),
+    ]
+    subprocess.run(cmd, check=True, text=True)
+
+    surface_csv = tmp_path / "surface.csv"
+    surface_png = tmp_path / "surface.png"
+    cmd = [
+        sys.executable,
+        str(script),
+        "analyze",
+        "surface",
+        "--from-candidates",
+        str(cand),
+        "--out-csv",
+        str(surface_csv),
+        "--plot",
+        str(surface_png),
+    ]
+    subprocess.run(cmd, check=True, text=True)
+
+    assert surface_csv.exists()
+    with open(pareto) as fh:
+        pareto_rows = list(csv.DictReader(fh))
+    with open(surface_csv) as fh:
+        surface_rows = list(csv.DictReader(fh))
+
+    surface_codes = {r["code"] for r in surface_rows}
+    pareto_codes = {r["code"] for r in pareto_rows}
+    assert pareto_codes.issubset(surface_codes)
+
+    frontier_codes = {r["code"] for r in surface_rows if r.get("frontier", "").lower() in ("true", "1")}
+    assert frontier_codes == pareto_codes
+
+    for r in surface_rows:
+        nesii = float(r["NESII"])
+        assert 0.0 <= nesii <= 100.0
+
+    hashes = {r["scenario_hash"] for r in surface_rows}
+    assert len(hashes) == 1 and list(hashes)[0]


### PR DESCRIPTION
## Summary
- add `analysis.surface` module to classify candidate sets, validate NESII bounds, stamp provenance, and plot dominated vs frontier points
- expose new `eccsim analyze surface` command to generate `surface.csv` and optional plot from candidates
- include test ensuring surface covers Pareto frontier and values are well-formed

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa9bad9b3c832ea183570dee51a142