### PR TITLE
Add hypervolume and spacing quality metrics

### DIFF
--- a/analysis/hv.py
+++ b/analysis/hv.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Hypervolume and spacing metrics for Pareto frontiers."""
+
+import math
+from typing import Iterable, Sequence
+
+import numpy as np
+
+
+def normalize(points: Iterable[Sequence[float]]) -> np.ndarray:
+    """Normalize points to the unit hypercube.
+
+    Each dimension is scaled to ``[0, 1]`` based on the min and max across
+    the provided points.  If a dimension has zero span the coordinate is kept
+    at ``0`` for all points.
+    """
+
+    arr = np.asarray(list(points), dtype=float)
+    if arr.size == 0:
+        return arr
+    mins = np.min(arr, axis=0)
+    maxs = np.max(arr, axis=0)
+    span = np.where(maxs - mins == 0, 1.0, maxs - mins)
+    return (arr - mins) / span
+
+
+def hypervolume(points: Iterable[Sequence[float]], ref: Sequence[float] | None = None) -> float:
+    """Compute the hypervolume of ``points`` for minimisation problems.
+
+    ``points`` are assumed to lie in the unit hypercube.  ``ref`` denotes the
+    reference point in normalized coordinates and defaults to ``(1, …, 1)``.
+    """
+
+    pts = [tuple(p) for p in points]
+    if not pts:
+        return 0.0
+    dim = len(pts[0])
+    if ref is None:
+        ref = (1.0,) * dim
+
+    pts.sort(key=lambda p: p[0])
+
+    def _hv(slice_pts: list[tuple[float, ...]], r: Sequence[float]) -> float:
+        if not slice_pts:
+            return 0.0
+        prev = r[0]
+        vol = 0.0
+        for i, p in enumerate(slice_pts):
+            dx = prev - p[0]
+            if len(r) == 1:
+                contrib = dx
+            else:
+                next_pts = [q[1:] for q in slice_pts[i:]]
+                contrib = dx * _hv(next_pts, r[1:])
+            vol += contrib
+            prev = p[0]
+        return vol
+
+    return float(_hv(pts, ref))
+
+
+def schott_spacing(points: Iterable[Sequence[float]]) -> float:
+    """Compute Schott's spacing metric for ``points``.
+
+    ``points`` are assumed to lie in the unit hypercube.
+    """
+
+    arr = np.asarray(list(points), dtype=float)
+    n = len(arr)
+    if n <= 1:
+        return 0.0
+    dists = []
+    for i in range(n):
+        diff = arr - arr[i]
+        dist = np.linalg.norm(diff, axis=1)
+        dist[i] = np.inf
+        dists.append(np.min(dist))
+    dists = np.asarray(dists)
+    dbar = np.mean(dists)
+    return float(math.sqrt(np.sum((dists - dbar) ** 2) / (n - 1)))
+
+
+__all__ = ["normalize", "hypervolume", "schott_spacing"]

--- a/tests/python/test_hv_metrics.py
+++ b/tests/python/test_hv_metrics.py
@@ -1,0 +1,13 @@
+from analysis.hv import hypervolume, schott_spacing
+
+
+def test_better_frontier_has_higher_hv():
+    worse = [(0.6, 0.6)]
+    better = [(0.4, 0.4)]
+    assert hypervolume(better) > hypervolume(worse)
+
+
+def test_clustered_points_reduce_spacing():
+    spread = [(0.0, 0.0), (0.5, 0.1), (0.9, 0.2)]
+    clustered = [(0.0, 0.0), (0.01, 0.01), (0.02, 0.02)]
+    assert schott_spacing(clustered) < schott_spacing(spread)

--- a/tests/python/test_selector_multiobj.py
+++ b/tests/python/test_selector_multiobj.py
@@ -82,3 +82,11 @@ def test_nesii_fallback_logs_once(caplog):
         "NESII degenerate scale; forcing score 50",
     ]
 
+
+def test_selector_quality_block():
+    res = select(["sec-ded-64", "sec-daec-64", "taec-64"], **_default_params())
+    q = res["quality"]
+    assert q["ref_point_norm"] == [1.0, 1.0, 1.0]
+    assert q["hypervolume"] >= 0.0
+    assert q["spacing"] >= 0.0
+

--- a/tests/python/test_tradeoff_analysis.py
+++ b/tests/python/test_tradeoff_analysis.py
@@ -34,4 +34,9 @@ def test_tradeoff_slope_and_ci(tmp_path: Path) -> None:
     result2 = analyze_tradeoffs(pareto, out2, cfg)
     assert result2["exchange"]["fit_vs_carbon"]["kg_per_decade"] == slope
 
+    quality = result["quality"]
+    assert quality["ref_point_norm"] == [1.0, 1.0]
+    assert quality["hypervolume"] > 0.0
+    assert quality["spacing"] >= 0.0
+
 


### PR DESCRIPTION
## Summary
- implement reusable hypervolume and Schott spacing utilities
- report frontier quality metrics in selector and tradeoff analyses
- add tests for hypervolume and spacing behaviour

## Testing
- `pytest tests/python/test_hv_metrics.py tests/python/test_selector_multiobj.py::test_selector_quality_block tests/python/test_tradeoff_analysis.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa95de6e8832e9a4bc348120149a1