### PR TITLE
Add one-factor sensitivity analysis

### DIFF
--- a/analysis/sensitivity.py
+++ b/analysis/sensitivity.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, List
+
+from ecc_selector import select
+
+
+@dataclass
+class SensitivityRun:
+    value: float
+    choice: str | None
+    feasible: List[str]
+
+
+def analyze_sensitivity(
+    scenario_json: Path, factor: str, grid: List[float], out_json: Path
+) -> Dict[str, Any]:
+    """Analyse robustness of the ECC recommendation against a single factor."""
+
+    scenario = json.loads(scenario_json.read_text())
+    if "codes" not in scenario:
+        raise KeyError("scenario missing 'codes'")
+    codes = scenario["codes"]
+    scenario_params = {k: v for k, v in scenario.items() if k != "codes" and k != "constraints"}
+    constraints = dict(scenario.get("constraints", {}))
+
+    runs: List[SensitivityRun] = []
+    for val in grid:
+        params = dict(scenario_params)
+        cons = dict(constraints)
+        if factor in params:
+            params[factor] = val
+        else:
+            cons[factor] = val
+
+        res = select(codes, constraints=cons if cons else None, **params)
+        best = res.get("best")
+        choice = best.get("code") if isinstance(best, dict) else None
+        if factor == "fit_max":
+            feasible = [
+                r["code"] for r in res.get("candidate_records", []) if r.get("FIT", float("inf")) <= val
+            ]
+        else:
+            feasible = [r["code"] for r in res.get("candidate_records", [])]
+        runs.append(SensitivityRun(value=float(val), choice=choice, feasible=feasible))
+
+    choices = {str(r.value): r.choice for r in runs}
+    feasible_map = {str(r.value): r.feasible for r in runs}
+
+    codes_list = [r.choice for r in runs]
+    if codes_list:
+        from collections import Counter
+
+        cnt = Counter(codes_list)
+        _, mode_count = cnt.most_common(1)[0]
+        robustness = mode_count / len(codes_list)
+    else:
+        robustness = 0.0
+
+    change_points: List[Dict[str, Any]] = []
+    for prev, curr in zip(runs, runs[1:]):
+        if prev.choice != curr.choice:
+            change_points.append({
+                "value": curr.value,
+                "from": prev.choice,
+                "to": curr.choice,
+            })
+
+    result = {
+        "factor": factor,
+        "grid": grid,
+        "choices": choices,
+        "feasible": feasible_map,
+        "robustness": robustness,
+        "change_points": change_points,
+    }
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(result, indent=2))
+    return result
+
+
+__all__ = ["analyze_sensitivity"]

--- a/eccsim.py
+++ b/eccsim.py
@@ -225,6 +225,14 @@ def main() -> None:
     surface_parser.add_argument("--out-csv", dest="out_csv", type=Path, required=True)
     surface_parser.add_argument("--plot", type=Path, default=None)
 
+    sens_parser = analyze_sub.add_parser(
+        "sensitivity", help="One-factor sensitivity analysis"
+    )
+    sens_parser.add_argument("--factor", type=str, required=True)
+    sens_parser.add_argument("--grid", type=str, required=True)
+    sens_parser.add_argument("--from", dest="from_json", type=Path, required=True)
+    sens_parser.add_argument("--out", type=Path, required=True)
+
     reliability_parser = sub.add_parser(
         "reliability", help="Reliability calculations"
     )
@@ -286,6 +294,11 @@ def main() -> None:
             from analysis.surface import analyze_surface
 
             analyze_surface(args.cand_csv, args.out_csv, args.plot)
+        elif args.analyze_command == "sensitivity":
+            from analysis.sensitivity import analyze_sensitivity
+
+            grid_vals = [float(x) for x in args.grid.split(",") if x.strip()]
+            analyze_sensitivity(args.from_json, args.factor, grid_vals, args.out)
         else:
             parser.error("analyze subcommand required")
         return

--- a/tests/python/test_sensitivity.py
+++ b/tests/python/test_sensitivity.py
@@ -1,0 +1,67 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_scenario(path: Path) -> Path:
+    scenario = {
+        "codes": ["sec-ded-64", "sec-daec-64", "taec-64"],
+        "node": 14,
+        "vdd": 0.8,
+        "temp": 75.0,
+        "scrub_s": 10.0,
+        "capacity_gib": 8.0,
+        "ci": 0.55,
+        "bitcell_um2": 0.040,
+    }
+    scen_path = path / "scenario.json"
+    scen_path.write_text(json.dumps(scenario))
+    return scen_path
+
+
+def _run(path: Path, scenario: Path, factor: str, grid: list[float], out: Path) -> dict:
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "analyze",
+        "sensitivity",
+        "--factor",
+        factor,
+        "--grid",
+        ",".join(str(x) for x in grid),
+        "--from",
+        str(scenario),
+        "--out",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True, text=True)
+    return json.loads(out.read_text())
+
+
+def test_sensitivity_deterministic(tmp_path: Path) -> None:
+    scen = _write_scenario(tmp_path)
+    out1 = tmp_path / "sens1.json"
+    out2 = tmp_path / "sens2.json"
+    data1 = _run(tmp_path, scen, "vdd", [0.72, 0.76], out1)
+    data2 = _run(tmp_path, scen, "vdd", [0.72, 0.76], out2)
+    assert data1 == data2
+
+
+def test_feasible_set_monotone(tmp_path: Path) -> None:
+    scen = _write_scenario(tmp_path)
+    out = tmp_path / "sens_fit.json"
+    grid = [1200.0, 1000.0, 900.0]
+    data = _run(tmp_path, scen, "fit_max", grid, out)
+    counts = [len(data["feasible"][str(g)]) for g in grid]
+    assert counts[0] >= counts[1] >= counts[2]
+
+
+def test_change_points_detected(tmp_path: Path) -> None:
+    scen = _write_scenario(tmp_path)
+    out = tmp_path / "sens_change.json"
+    grid = [2000.0, 1000.0, 800.0]
+    data = _run(tmp_path, scen, "fit_max", grid, out)
+    cps = data["change_points"]
+    assert cps and cps[0]["value"] == 1000.0


### PR DESCRIPTION
## Summary
- add sensitivity analyzer to explore robustness of ECC recommendations across a factor grid
- integrate `eccsim analyze sensitivity` subcommand to call the analyzer
- test deterministic results, feasible-set monotonicity, and change-point detection

## Testing
- `pytest tests/python/test_sensitivity.py -q`
- `pytest tests/python/test_surface_analysis.py::test_surface_analysis -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaab0c5e34832e9c2599ffc31271db