### PR TITLE
Externalize archetype configuration

### DIFF
--- a/configs/archetypes.yaml
+++ b/configs/archetypes.yaml
@@ -1,0 +1,30 @@
+version: 1
+archetypes:
+  Fortress:
+    fit_lo: 0.0
+    fit_hi: 1e-15
+    lat_lo: 3.0
+    lat_hi: .inf
+    carbon_lo: 0.8
+    carbon_hi: 1.2
+  Efficiency:
+    fit_lo: 1e-13
+    fit_hi: 1e-12
+    lat_lo: 1.5
+    lat_hi: 2.5
+    carbon_lo: 0.3
+    carbon_hi: 0.6
+  Frugal:
+    fit_lo: 1e-12
+    fit_hi: 1e-11
+    lat_lo: 0.0
+    lat_hi: 2.0
+    carbon_lo: 0.0
+    carbon_hi: 0.3
+  SpeedDemon:
+    fit_lo: 0.0
+    fit_hi: .inf
+    lat_lo: 0.0
+    lat_hi: 1.5
+    carbon_lo: 0.4
+    carbon_hi: .inf

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 pytest
 jsonschema
 matplotlib
+pyyaml

--- a/tests/python/test_archetype_analysis.py
+++ b/tests/python/test_archetype_analysis.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 import pandas as pd
+import yaml
 
-from analysis.archetype import classify_archetypes
+from analysis.archetype import classify_archetypes, _load_archetypes
 
 
 def create_data(tmp_path: Path) -> Path:
@@ -26,4 +27,36 @@ def test_archetype_classification(tmp_path: Path) -> None:
     assert result["counts"]["Efficiency"] == 1
     assert result["counts"]["Frugal"] == 1
     assert result["counts"]["SpeedDemon"] == 1
+    assert "version" in result["provenance"]
+
+
+def test_archetype_config_tweak(tmp_path: Path) -> None:
+    pareto = create_data(tmp_path)
+    out = tmp_path / "arch.json"
+    result = classify_archetypes(pareto, out)
+    assert result["counts"]["Efficiency"] == 1
+
+    repo_root = Path(__file__).resolve().parents[2]
+    cfg = yaml.safe_load((repo_root / "configs" / "archetypes.yaml").read_text())
+    cfg["archetypes"]["Efficiency"]["fit_hi"] = 1e-13
+    cfg_path = tmp_path / "arcs.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    out2 = tmp_path / "arch2.json"
+    result2 = classify_archetypes(pareto, out2, cfg_path)
+    assert result2["counts"].get("Efficiency", 0) == 0
+    assert result2["counts"]["Unknown"] == 1
+
+
+def test_confidence_monotone() -> None:
+    _, arcs, _ = _load_archetypes()
+    eff = arcs["Efficiency"]
+    c = eff.center
+    row_center = pd.Series(c)
+    row_mid = pd.Series(c)
+    row_mid["carbon_kg"] = c["carbon_kg"] + (eff.carbon_hi - c["carbon_kg"]) / 2
+    row_edge = pd.Series({"fit": c["fit"], "latency_ns": c["latency_ns"], "carbon_kg": eff.carbon_hi})
+    conf_center = eff.matches(row_center)
+    conf_mid = eff.matches(row_mid)
+    conf_edge = eff.matches(row_edge)
+    assert conf_center > conf_mid > conf_edge
 


### PR DESCRIPTION
## Summary
- load archetype thresholds from new `configs/archetypes.yaml`
- include archetype version and thresholds in classification outputs
- allow config path override and document provenance
- add unit tests for config tweaks and confidence monotonicity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaaf94bb28832eb27c38b13793e77b