### PR TITLE
Add bootstrap controls and filtering provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ are available under the new `analyze` command family:
 ```bash
 eccsim select --codes sec-ded,sec-daec --node 7 --vdd 0.8 --temp 25 --capacity-gib 1 --ci 400 --bitcell-um2 0.1 --report pareto.csv
 
-eccsim analyze tradeoffs --from pareto.csv --out reports/tradeoffs.json
+eccsim analyze tradeoffs --from pareto.csv --out reports/tradeoffs.json \
+    --bootstrap 20000 --seed 1 --filter "carbon_kg < 2"
 
 eccsim analyze archetype --from pareto.csv --out reports/archetype.json
 ```

--- a/analysis/tradeoff.py
+++ b/analysis/tradeoff.py
@@ -16,7 +16,7 @@ from analysis.hv import normalize, hypervolume, schott_spacing
 class TradeoffConfig:
     """Configuration for trade-off analysis."""
 
-    n_resamples: int = 10000
+    n_resamples: int = 20000
     seed: int = 0
     filter_expr: Optional[str] = None
     basis: str = "per_gib"
@@ -96,6 +96,10 @@ def analyze_tradeoffs(pareto_csv: Path, out_json: Path, cfg: TradeoffConfig) -> 
     result = {
         "provenance": {
             "basis": cfg.basis,
+            "ci_method": "bootstrap",
+            "seed": cfg.seed,
+            "n_resamples": cfg.n_resamples,
+            "filter": cfg.filter_expr,
             "notes": [],
         },
         "exchange": {
@@ -115,8 +119,6 @@ def analyze_tradeoffs(pareto_csv: Path, out_json: Path, cfg: TradeoffConfig) -> 
             "spacing": spacing,
         },
     }
-    if cfg.filter_expr:
-        result["filter"] = cfg.filter_expr
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_json.write_text(json.dumps(result, indent=2))

--- a/eccsim.py
+++ b/eccsim.py
@@ -243,7 +243,7 @@ def main() -> None:
     trade_parser.add_argument("--basis", choices=["per_gib", "system"], default="per_gib")
     trade_parser.add_argument("--filter", type=str, default=None)
     trade_parser.add_argument("--seed", type=int, default=0)
-    trade_parser.add_argument("--resamples", type=int, default=10000)
+    trade_parser.add_argument("--bootstrap", type=int, default=20000)
 
     arch_parser = analyze_sub.add_parser("archetype", help="Classify archetypes")
     arch_parser.add_argument("--from", dest="from_csv", type=Path, required=True)
@@ -316,7 +316,7 @@ def main() -> None:
             from analysis.tradeoff import TradeoffConfig, analyze_tradeoffs
 
             cfg = TradeoffConfig(
-                n_resamples=args.resamples,
+                n_resamples=args.bootstrap,
                 seed=args.seed,
                 filter_expr=args.filter,
                 basis=args.basis,


### PR DESCRIPTION
## Summary
- Allow setting tradeoff bootstrap resamples via `--bootstrap` and store reproducibility info.
- Record CI method, seed, resample count, and active filters in tradeoff analysis output.
- Test that fixed seeds yield stable CIs and filters still compute statistics on reduced datasets.

## Testing
- `pytest tests/python/test_tradeoff_analysis.py -q`
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aab11438e4832eb43791c8540b91cd