### PR TITLE
docs: add quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This repository collects C++ and Python tools for exploring error-correcting-code (ECC) schemes in SRAM and evaluating their reliability, energy cost and environmental footprint. It includes standalone memory simulators, comparison utilities and analytical scripts.
 
+## Quick Start
+
+Clone the repository and run a minimal simulator with:
+
+```bash
+pip install -r requirements.txt
+make
+./Hamming32bit1Gb
+```
+
+The sample run prints correction statistics and creates `ecc_stats` and `decoding_results` logs in the project root.
+
 ---
 
 ## 1. Dependencies


### PR DESCRIPTION
## Summary
- add a Quick Start section with basic install, build, and run commands for a sample simulator

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aac48fda74832e8ae4d975b36bcdaa