### PR TITLE
Fix leakage energy units

### DIFF
--- a/energy_model.py
+++ b/energy_model.py
@@ -281,12 +281,18 @@ def depth_locator(code: str) -> int:
 # Leakage model
 
 
-_LEAK_BASE = {28: 0.5, 16: 0.7, 7: 1.0}  # A/mm^2 at 25C
+# Leakage current density reference values expressed in microamps per square
+# millimetre (\u03bcA/mm^2) at 25\u00b0C. Prior revisions treated these as amps,
+# greatly overstating leakage energy.
+_LEAK_BASE_UA_PER_MM2 = {28: 0.5, 16: 0.7, 7: 1.0}
 
 
 def i_leak_density_A_per_mm2(node_nm: float, temp_c: float) -> float:
-    nodes = np.array(sorted(_LEAK_BASE))
-    base = np.array([_LEAK_BASE[n] for n in nodes])
+    """Return leakage current density in A/mm^2."""
+    nodes = np.array(sorted(_LEAK_BASE_UA_PER_MM2))
+    base_ua = np.array([_LEAK_BASE_UA_PER_MM2[n] for n in nodes])
+    # Convert microamp calibration data to amps before temperature scaling.
+    base = base_ua * 1e-6
     density_25 = np.interp(node_nm, nodes, base)
     return density_25 * 2 ** ((temp_c - 25.0) / 10.0)
 

--- a/tests/python/test_energy_model.py
+++ b/tests/python/test_energy_model.py
@@ -84,3 +84,14 @@ def test_leakage_energy_monotonic():
     small_area = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1)
     large_area = energy_model.leakage_energy_j(0.8, 28, 75, "taec", 1)
     assert large_area > small_area
+
+
+def test_leakage_scale_fixed_units():
+    # Baseline leakage density for 16nm at 25C is 0.7 µA/mm^2 which should
+    # translate to 0.7e-6 A/mm^2.
+    assert energy_model.i_leak_density_A_per_mm2(16, 25) == pytest.approx(0.7e-6)
+
+    # For a typical scenario, leakage energy should be within a sane range and
+    # nowhere near the multi-megajoule values seen prior to unit corrections.
+    leak = energy_model.leakage_energy_j(0.8, 16, 45, "sec-ded", 1e4)
+    assert leak < 1e4


### PR DESCRIPTION
## Summary
- Correct leakage current density calibration to use microamps per mm²
- Prevent unrealistic leakage energy outputs and add unit-scale regression test

## Testing
- `python eccsim.py energy --code sec-ded --node 16 --vdd 0.8 --temp 45 --ops 1e6 --lifetime-h 1e4`
- `python eccsim.py energy --code sec-ded --node 16 --vdd 0.8 --temp 100 --ops 1e6 --lifetime-h 1e4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacfe196c4832e86c8239e672d9c0a