### PR TITLE
Centralize calibration loader and unify sustainability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Demonstrates a small DPLL SAT solver used for Hamming-code conjectures, printing
 
 Central CLI exposing reliability, energy and carbon analysis.
 
+- **ESII metrics** – the `esii` subcommand now also reports NESII and the
+  Green Score (GS) alongside raw ESII for the given scenario.
 - **Reliability report** – computes FIT rates and mean-time-to-failure:
 
   ```bash
@@ -154,6 +156,10 @@ python3 energy_model.py 8 1
 ```
 
 Outputs a single line like `Estimated energy per read: 2.0e-12 J`.
+
+The helper module `calibration.py` centralises parsing of
+`tech_calib.json` so that Python utilities and external frameworks can
+share the same validated calibration data.
 
 #### 3.2.3 `ecc_selector.py`
 

--- a/calibration.py
+++ b/calibration.py
@@ -1,0 +1,61 @@
+"""Shared technology calibration loader.
+
+This module centralises parsing of :mod:`tech_calib.json` so that both
+Python utilities and any external tooling can rely on a single validated
+schema.  It returns a nested mapping indexed by technology node and
+voltage, mirroring the structure used by :mod:`energy_model`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def load_calibration(path: Path) -> Dict[int, Dict[float, dict]]:
+    """Load and validate gate energy calibration data.
+
+    Parameters
+    ----------
+    path : Path
+        Location of the JSON calibration file.
+
+    Returns
+    -------
+    dict
+        Nested mapping ``{node_nm: {vdd: entry}}`` where ``entry`` contains
+        metadata and gate energy information.
+    """
+    raw = json.load(open(path))
+    calib: Dict[int, Dict[float, dict]] = {}
+    for node_str, node_data in raw.items():
+        node = int(node_str)
+        calib[node] = {}
+        for vdd_str, entry in node_data.items():
+            vdd = float(vdd_str)
+            required = {"source", "date", "tempC", "gates"}
+            missing = required - entry.keys()
+            if missing:
+                raise ValueError(
+                    f"Missing {missing} for node {node_str} VDD {vdd_str}"
+                )
+            gates = entry["gates"]
+            if set(gates) != {"xor", "and", "adder_stage"}:
+                raise ValueError(
+                    f"Missing gate energies for node {node_str} VDD {vdd_str}"
+                )
+            calib[node][vdd] = {
+                "source": entry["source"],
+                "date": entry["date"],
+                "tempC": entry["tempC"],
+                "gates": gates,
+            }
+        vols_sorted = sorted(calib[node])
+        for gate_name in ["xor", "and", "adder_stage"]:
+            vals = [calib[node][vol]["gates"][gate_name] for vol in vols_sorted]
+            if any(b < a for a, b in zip(vals, vals[1:])):
+                raise ValueError(
+                    f"{gate_name} energy non-monotonic in VDD for node {node_str}"
+                )
+    return calib

--- a/eccsim.py
+++ b/eccsim.py
@@ -21,7 +21,8 @@ import json
 import sys
 from typing import Dict
 
-from esii import ESIIInputs, compute_esii
+from esii import ESIIInputs
+from scores import compute_scores
 from carbon import embodied_kgco2e, operational_kgco2e, default_alpha
 from ser_model import HazuchaParams, ser_hazucha, flux_from_location
 from qcrit_loader import qcrit_lookup
@@ -412,6 +413,7 @@ def main() -> None:
                 "latency_ns",
                 "ESII",
                 "NESII",
+                "GS",
                 "p5",
                 "p95",
                 "N_scale",
@@ -441,6 +443,7 @@ def main() -> None:
                 "latency_ns",
                 "ESII",
                 "NESII",
+                "GS",
                 "areas",
                 "energies",
                 "violations",
@@ -539,6 +542,7 @@ def main() -> None:
             "carbon_kg",
             "ESII",
             "NESII",
+            "GS",
             "scrub_s",
             "area_logic_mm2",
             "area_macro_mm2",
@@ -654,7 +658,7 @@ def main() -> None:
             ci_kgco2e_per_kwh=args.ci,
             embodied_kgco2e=embodied,
         )
-        result = compute_esii(inp)
+        result = compute_scores(inp, latency_ns=0.0)
 
         provenance = {
             "git": git_hash,
@@ -680,6 +684,10 @@ def main() -> None:
             },
             "delta_FIT": result["delta_FIT"],
             "ESII": result["ESII"],
+            "NESII": result["NESII"],
+            "GS": result["GS"],
+            "p5": result["p5"],
+            "p95": result["p95"],
         }
 
         if args.out:

--- a/energy_model.py
+++ b/energy_model.py
@@ -9,51 +9,14 @@ linear interpolation over voltage and node and return energies in joules
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
-from typing import Dict, Sequence
+from typing import Sequence
 
 import numpy as np
 import math
 
-
-
-def _load_calib(path: Path) -> Dict[int, Dict[float, dict]]:
-    """Load and validate gate energy calibration data."""
-    raw = json.load(open(path))
-    calib: Dict[int, Dict[float, dict]] = {}
-    for node_str, node_data in raw.items():
-        node = int(node_str)
-        calib[node] = {}
-        for vdd_str, entry in node_data.items():
-            vdd = float(vdd_str)
-            required = {"source", "date", "tempC", "gates"}
-            missing = required - entry.keys()
-            if missing:
-                raise ValueError(
-                    f"Missing {missing} for node {node_str} VDD {vdd_str}"
-                )
-            gates = entry["gates"]
-            if set(gates) != {"xor", "and", "adder_stage"}:
-                raise ValueError(
-                    f"Missing gate energies for node {node_str} VDD {vdd_str}"
-                )
-            calib[node][vdd] = {
-                "source": entry["source"],
-                "date": entry["date"],
-                "tempC": entry["tempC"],
-                "gates": gates,
-            }
-
-        vols_sorted = sorted(calib[node])
-        for gate_name in ["xor", "and", "adder_stage"]:
-            vals = [calib[node][vol]["gates"][gate_name] for vol in vols_sorted]
-            if any(b < a for a, b in zip(vals, vals[1:])):
-                raise ValueError(
-                    f"{gate_name} energy non-monotonic in VDD for node {node_str}"
-                )
-    return calib
+from calibration import load_calibration as _load_calib
 
 
 _CALIB = _load_calib(Path(__file__).with_name("tech_calib.json"))

--- a/scores.py
+++ b/scores.py
@@ -1,0 +1,68 @@
+"""Unified sustainability metrics interface.
+
+This module provides a convenience wrapper to compute ESII, NESII and the
+Green Score (GS) in a single call.  The helper accepts the standard
+:class:`esii.ESIIInputs` structure along with a latency value used by the
+GS calculation.  Optionally a reference distribution of ESII values can be
+supplied to obtain a normalised ESII (NESII); if omitted the NESII for the
+provided scenario defaults to 0.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from esii import ESIIInputs, compute_esii, normalise_esii
+from gs import GSInputs, compute_gs
+
+
+def compute_scores(
+    esii_inputs: ESIIInputs,
+    *,
+    latency_ns: float = 0.0,
+    esii_reference: Iterable[float] | None = None,
+) -> Dict[str, float]:
+    """Return ESII, NESII and GS for the provided inputs.
+
+    Parameters
+    ----------
+    esii_inputs:
+        Parameters describing reliability and carbon components.  Passed
+        directly to :func:`esii.compute_esii`.
+    latency_ns:
+        Additional decode latency to include in the GS calculation.  Defaults
+        to ``0.0`` which treats the candidate as latency‑neutral.
+    esii_reference:
+        Optional iterable of ESII values used to derive percentile anchors for
+        NESII normalisation.  The provided ESII result is appended to this
+        sequence before calling :func:`esii.normalise_esii`.  When omitted the
+        NESII score is zero with percentile bounds equal to the raw ESII.
+    """
+
+    esii_res = compute_esii(esii_inputs)
+    esii_val = esii_res["ESII"]
+
+    ref: List[float]
+    if esii_reference is None:
+        ref = [esii_val]
+    else:
+        ref = list(esii_reference) + [esii_val]
+
+    nesii_scores, p5, p95 = normalise_esii(ref)
+    nesii_val = nesii_scores[-1] if nesii_scores else float("nan")
+
+    gs_inp = GSInputs(
+        fit_base=esii_inputs.fit_base,
+        fit_ecc=esii_inputs.fit_ecc,
+        carbon_kg=esii_res["total_kgCO2e"],
+        latency_ns=latency_ns,
+    )
+    gs_res = compute_gs(gs_inp)
+
+    out = dict(esii_res)
+    out.update({"NESII": nesii_val, "p5": p5, "p95": p95})
+    out.update({"GS": gs_res["GS"]})
+    return out
+
+
+__all__ = ["compute_scores"]

--- a/tests/python/test_calibration.py
+++ b/tests/python/test_calibration.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import calibration
+
+
+def test_load_calibration():
+    path = Path(__file__).resolve().parents[2] / "tech_calib.json"
+    data = calibration.load_calibration(path)
+    assert 28 in data
+    assert 0.8 in data[28]
+    assert data[28][0.8]["gates"]["xor"] > 0

--- a/tests/python/test_esii.py
+++ b/tests/python/test_esii.py
@@ -3,13 +3,11 @@ import sys
 from pathlib import Path
 import math
 import json
-import subprocess
-import sys
-from pathlib import Path
 
 import pytest
 
 from esii import ESIIInputs, compute_esii, embodied_from_wire_area
+from gs import GSInputs, compute_gs
 
 
 def test_compute_esii():
@@ -69,7 +67,17 @@ def test_cli_esii_outputs_result(tmp_path):
         embodied_kgco2e=0.05,
     )
     expected = compute_esii(inp)
+    gs_exp = compute_gs(
+        GSInputs(
+            fit_base=inp.fit_base,
+            fit_ecc=inp.fit_ecc,
+            carbon_kg=expected["total_kgCO2e"],
+            latency_ns=0.0,
+        )
+    )
     assert data["ESII"] == pytest.approx(expected["ESII"])
+    assert data["NESII"] == 0.0
+    assert data["GS"] == pytest.approx(gs_exp["GS"])
     assert data["basis"] == "per_gib"
     assert data["inputs"]["E_scrub_kWh"] == 0.0
 
@@ -125,7 +133,17 @@ def test_cli_esii_reports(tmp_path):
         embodied_kgco2e=0.1 * 0.8 + 0.2 * 1.0,
     )
     expected = compute_esii(inp)
+    gs_exp = compute_gs(
+        GSInputs(
+            fit_base=inp.fit_base,
+            fit_ecc=inp.fit_ecc,
+            carbon_kg=expected["total_kgCO2e"],
+            latency_ns=0.0,
+        )
+    )
     assert data["ESII"] == pytest.approx(expected["ESII"])
+    assert data["NESII"] == 0.0
+    assert data["GS"] == pytest.approx(gs_exp["GS"])
     assert data["inputs"]["fit_base"] == 300.0
     assert data["inputs"]["E_scrub_kWh"] == 0.0
 

--- a/tests/python/test_scores.py
+++ b/tests/python/test_scores.py
@@ -1,0 +1,36 @@
+import math
+
+import pytest
+
+from esii import ESIIInputs, compute_esii, normalise_esii
+from gs import GSInputs, compute_gs
+from scores import compute_scores
+
+
+def test_compute_scores_matches_components():
+    inp = ESIIInputs(
+        fit_base=500.0,
+        fit_ecc=50.0,
+        e_dyn=2_000_000.0,
+        e_leak=1_000_000.0,
+        ci_kgco2e_per_kwh=0.3,
+        embodied_kgco2e=2.0,
+    )
+    ref = [10.0, 20.0, 30.0]
+    res = compute_scores(inp, latency_ns=1.0, esii_reference=ref)
+
+    esii_expected = compute_esii(inp)
+    gs_expected = compute_gs(
+        GSInputs(
+            fit_base=inp.fit_base,
+            fit_ecc=inp.fit_ecc,
+            carbon_kg=esii_expected["total_kgCO2e"],
+            latency_ns=1.0,
+        )
+    )
+    _, p5_exp, p95_exp = normalise_esii(ref + [res["ESII"]])
+    assert math.isclose(res["ESII"], esii_expected["ESII"])
+    assert math.isclose(res["GS"], gs_expected["GS"])
+    assert 0.0 <= res["NESII"] <= 100.0
+    assert res["p5"] == pytest.approx(p5_exp)
+    assert res["p95"] == pytest.approx(p95_exp)


### PR DESCRIPTION
## Summary
- add `compute_scores` helper returning ESII, NESII and Green Score (GS)
- update `eccsim.py` to emit NESII/GS and include GS in reports
- document combined ESII/NESII/GS reporting in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac9b012104832e8c392b7e54d94385