### PR TITLE
feat: refine energy model with scalable gate counts and leakage corners

### DIFF
--- a/docs/EnergyModel.md
+++ b/docs/EnergyModel.md
@@ -1,14 +1,21 @@
 # Energy Model
 
 This module provides a tiny energy estimation for each read operation in the
-simulators. It multiplies the number of XOR and AND gate evaluations by
-technology-aware energy costs loaded from `tech_calib.json`.
+simulators. It multiplies the number of primitive gate evaluations by
+technology-aware energy costs loaded from `tech_calib.json`. Gate counts scale
+linearly with the ECC word size so wider codewords incur proportionally higher
+dynamic energy.
 
 ## Calibration
 
 `tech_calib.json` maps process node and voltage to per-gate energy figures for
-XOR and AND operations. The loader performs piecewise linear interpolation over
-this table so the estimate reflects the chosen technology and supply voltage.
+XOR, AND and adder primitives. The loader performs piecewise linear
+interpolation over this table so the estimate reflects the chosen technology and
+supply voltage.
+
+The leakage model now accepts a process corner argument (`ss`, `tt`, `ff`) and
+uses a gentler temperature coefficient, roughly doubling every 15 °C. This gives
+a more realistic view of static power across operating conditions.
 
 ## Running the script
 

--- a/tests/python/test_energy_model.py
+++ b/tests/python/test_energy_model.py
@@ -76,6 +76,12 @@ def test_dynamic_energy_scales_with_ops():
     assert e2 == pytest.approx(2 * e1)
 
 
+def test_dynamic_energy_scales_with_word_bits():
+    e64 = energy_model.dynamic_energy_per_op("sec-ded", 28, 0.8, word_bits=64)
+    e128 = energy_model.dynamic_energy_per_op("sec-ded", 28, 0.8, word_bits=128)
+    assert e128 == pytest.approx(2 * e64)
+
+
 def test_leakage_energy_monotonic():
     low_temp = energy_model.leakage_energy_j(0.8, 28, 25, "sec-ded", 1)
     high_temp = energy_model.leakage_energy_j(0.8, 28, 35, "sec-ded", 1)
@@ -84,6 +90,13 @@ def test_leakage_energy_monotonic():
     small_area = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1)
     large_area = energy_model.leakage_energy_j(0.8, 28, 75, "taec", 1)
     assert large_area > small_area
+
+
+def test_leakage_corner_factor():
+    tt = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1, corner="tt")
+    ff = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1, corner="ff")
+    ss = energy_model.leakage_energy_j(0.8, 28, 75, "sec-ded", 1, corner="ss")
+    assert ff > tt > ss
 
 
 def test_leakage_scale_fixed_units():


### PR DESCRIPTION
## Summary
- scale primitive gate counts with ECC word size for dynamic energy estimates
- introduce process-corner aware leakage model with gentler temperature scaling
- document updated energy model behaviour and add regression tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68aedf2740ec832eb2e04200a8508a21