### PR TITLE
Use calibrated gate energies in telemetry

### DIFF
--- a/SecDaec64.hpp
+++ b/SecDaec64.hpp
@@ -157,7 +157,7 @@ inline SecDaec64::DecodingResult SecDaec64::decode(CodeWord recv) const {
                 data |= (1ULL<<i);
         res.data = data;
         std::ofstream ofs("secdaec_energy.csv", std::ios::app);
-        ofs << t.xor_ops << ',' << t.and_ops << ',' << estimate_energy(t) << '\n';
+        ofs << t.xor_ops << ',' << t.and_ops << '\n';
         return res; // clean
     }
 
@@ -182,7 +182,7 @@ inline SecDaec64::DecodingResult SecDaec64::decode(CodeWord recv) const {
     res.data = data;
     {
         std::ofstream ofs("secdaec_energy.csv", std::ios::app);
-        ofs << t.xor_ops << ',' << t.and_ops << ',' << estimate_energy(t) << '\n';
+        ofs << t.xor_ops << ',' << t.and_ops << '\n';
     }
     return res;
 }

--- a/telemetry.hpp
+++ b/telemetry.hpp
@@ -1,21 +1,28 @@
 #ifndef TELEMETRY_HPP
 #define TELEMETRY_HPP
 #include <cstdint>
+#include "src/energy_loader.hpp"
+
 struct Telemetry {
     uint32_t xor_ops = 0;
     uint32_t and_ops = 0;
 };
+
 inline bool XOR(bool a, bool b, Telemetry &t) {
     t.xor_ops++;
     return a ^ b;
 }
+
 inline bool AND(bool a, bool b, Telemetry &t) {
     t.and_ops++;
     return a & b;
 }
-inline double estimate_energy(const Telemetry& t) {
-    constexpr double E_XOR = 2e-12;
-    constexpr double E_AND = 1e-12;
-    return t.xor_ops * E_XOR + t.and_ops * E_AND;
+
+inline double estimate_energy(const Telemetry& t,
+                              int node_nm, double vdd,
+                              const std::string& path = "tech_calib.json") {
+    const auto energies = load_gate_energies(node_nm, vdd, path);
+    return t.xor_ops * energies.xor_energy +
+           t.and_ops * energies.and_energy;
 }
 #endif // TELEMETRY_HPP


### PR DESCRIPTION
## Summary
- Load XOR and AND energies from the calibration table instead of hard-coded constants
- Trim SecDaec64 telemetry logs to only record XOR/AND toggle counts

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aee345c59c832ebe9db884804487da