### PR TITLE
Add SRAM MUX trade-off model

### DIFF
--- a/mux_model.py
+++ b/mux_model.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""SRAM column multiplexer trade-off modelling.
+
+This module evaluates three multiplexer sharing ratios (4, 8 and 16) for a
+256-column SRAM array.  It produces metrics such as total area, latency and an
+energy--delay style figure of merit alongside coarse carbon-footprint
+estimates.  The calculations mirror the analytical table discussed in the
+project documentation and are intended for quick experimentation rather than
+layout-accurate prediction.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+CARBON_INTENSITY = 0.000111  # g CO₂ per joule
+EMBODIED_PER_UM2 = 5e-6      # g CO₂ per square micron
+COLUMNS = 256
+SA_AREA_UM2 = 20.0           # area of a sense amplifier
+
+# Modelling parameters for each MUX configuration.
+#   mux_area_input : area in µm² for each input leg of the mux
+#   energy_pj      : dynamic energy per read in pJ
+#   latency_ns     : added read latency in ns
+_MUX_PARAMS = {
+    4: {"mux_area_input": 2.0, "energy_pj": 1.2, "latency_ns": 0.8},
+    8: {"mux_area_input": 2.4, "energy_pj": 1.0, "latency_ns": 1.0},
+    16: {"mux_area_input": 3.0, "energy_pj": 1.1, "latency_ns": 1.3},
+}
+
+
+@dataclass(frozen=True)
+class MuxMetrics:
+    sense_amps: int
+    total_area_um2: float
+    latency_ns: float
+    dyn_energy_pj: float
+    esii: float  # energy × delay product in pJ·ns
+    nesii: float
+    green_score: float
+    operational_energy_kj: float
+    operational_footprint_g: float
+    embodied_footprint_g: float
+
+
+def _raw_metrics(ratio: int) -> Dict[str, float]:
+    params = _MUX_PARAMS[ratio]
+    sa_count = COLUMNS // ratio
+    mux_area = ratio * params["mux_area_input"]
+    total_area = sa_count * (SA_AREA_UM2 + mux_area)
+
+    latency = params["latency_ns"]
+    energy_pj = params["energy_pj"]
+    esii = latency * energy_pj
+
+    energy_j = energy_pj * 1e-12
+    op_energy_j = energy_j * 1e15  # for 10^15 reads
+    op_energy_kj = op_energy_j / 1000.0
+    op_footprint = op_energy_j * CARBON_INTENSITY
+    embodied = total_area * EMBODIED_PER_UM2
+
+    return {
+        "sense_amps": sa_count,
+        "total_area_um2": total_area,
+        "latency_ns": latency,
+        "dyn_energy_pj": energy_pj,
+        "esii": esii,
+        "operational_energy_kj": op_energy_kj,
+        "operational_footprint_g": op_footprint,
+        "embodied_footprint_g": embodied,
+    }
+
+
+def evaluate_mux_configs() -> Dict[int, MuxMetrics]:
+    """Return metrics for all supported MUX sharing ratios."""
+
+    raw: Dict[int, Dict[str, float]] = {
+        ratio: _raw_metrics(ratio) for ratio in _MUX_PARAMS
+    }
+    best_esii = min(v["esii"] for v in raw.values())
+    for v in raw.values():
+        v["nesii"] = v["esii"] / best_esii
+        v["green_score"] = 100.0 / v["nesii"]
+    return {r: MuxMetrics(**vals) for r, vals in raw.items()}
+
+
+__all__ = ["MuxMetrics", "evaluate_mux_configs"]

--- a/tests/python/test_mux_model.py
+++ b/tests/python/test_mux_model.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mux_model import evaluate_mux_configs
+
+
+def test_mux_metrics_table():
+    res = evaluate_mux_configs()
+    assert set(res) == {4, 8, 16}
+
+    m4 = res[4]
+    assert m4.sense_amps == 64
+    assert m4.total_area_um2 == pytest.approx(1792.0)
+    assert m4.latency_ns == pytest.approx(0.8)
+    assert m4.dyn_energy_pj == pytest.approx(1.2)
+    assert m4.esii == pytest.approx(0.96)
+    assert m4.nesii == pytest.approx(1.0)
+    assert m4.green_score == pytest.approx(100.0)
+    assert m4.operational_energy_kj == pytest.approx(1.2)
+    assert m4.operational_footprint_g == pytest.approx(0.1332, rel=1e-3)
+    assert m4.embodied_footprint_g == pytest.approx(0.00896, rel=1e-3)
+
+    m8 = res[8]
+    assert m8.sense_amps == 32
+    assert m8.total_area_um2 == pytest.approx(1254.4)
+    assert m8.latency_ns == pytest.approx(1.0)
+    assert m8.dyn_energy_pj == pytest.approx(1.0)
+    assert m8.esii == pytest.approx(1.0)
+    assert m8.nesii == pytest.approx(1.04, rel=1e-2)
+    assert m8.green_score == pytest.approx(96.0, rel=1e-2)
+    assert m8.operational_energy_kj == pytest.approx(1.0)
+    assert m8.operational_footprint_g == pytest.approx(0.111, rel=1e-3)
+    assert m8.embodied_footprint_g == pytest.approx(0.00627, rel=1e-3)
+
+    m16 = res[16]
+    assert m16.sense_amps == 16
+    assert m16.total_area_um2 == pytest.approx(1088.0)
+    assert m16.latency_ns == pytest.approx(1.3)
+    assert m16.dyn_energy_pj == pytest.approx(1.1)
+    assert m16.esii == pytest.approx(1.43)
+    assert m16.nesii == pytest.approx(1.49, rel=1e-2)
+    assert m16.green_score == pytest.approx(67.11, rel=1e-2)
+    assert m16.operational_energy_kj == pytest.approx(1.1)
+    assert m16.operational_footprint_g == pytest.approx(0.1221, rel=1e-3)
+    assert m16.embodied_footprint_g == pytest.approx(0.00544, rel=1e-3)


### PR DESCRIPTION
## Summary
- add `mux_model` module to estimate area, latency, energy and carbon footprints for MUX4/8/16 SRAM column sharing
- provide table-driven test verifying computed metrics against analytical expectations

## Testing
- `pytest -q tests/python/test_mux_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba2d63d52c832eb0288062d8d96c29