### PR TITLE
Add ECC mux metrics to SRAM benchmark

### DIFF
--- a/ecc_mux.py
+++ b/ecc_mux.py
@@ -1,0 +1,29 @@
+"""Simple ECC multiplexer parameter helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+# Latency in ns, energy in pJ, area in square microns for each ECC scheme.
+_MUX_TABLE: Dict[str, Tuple[float, float, float]] = {
+    "Hamming_SEC": (0.05, 0.02, 1.0),
+    "SEC_DED": (0.06, 0.025, 1.2),
+    "TAEC": (0.07, 0.03, 1.4),
+    "DEC": (0.08, 0.035, 1.6),
+}
+
+
+def compute_ecc_mux_params(scheme: str) -> Tuple[float, float, float]:
+    """Return multiplexer latency, energy and area for *scheme*.
+
+    Parameters are derived from a simple look-up table and are intended for
+    illustrative benchmarking rather than detailed circuit modelling.
+    """
+
+    try:
+        return _MUX_TABLE[scheme]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown scheme: {scheme}") from exc
+
+
+__all__ = ["compute_ecc_mux_params"]

--- a/sram_ecc_benchmark.py
+++ b/sram_ecc_benchmark.py
@@ -1,6 +1,8 @@
 """SRAM bit error rate and ECC benchmarking utilities."""
 
 from math import exp
+
+from ecc_mux import compute_ecc_mux_params
 from esii import ESIIInputs, compute_esii
 from scores import compute_scores
 
@@ -121,6 +123,7 @@ def sustainability_benchmark(node: str, capacity_mb: float) -> None:
 
     esii_inputs = {}
     esii_vals = []
+    mux_metrics = {}
     for scheme in schemes:
         params = SUSTAINABILITY_PARAMS[scheme]
         uncorr = residual_error_rate(scheme)
@@ -134,12 +137,15 @@ def sustainability_benchmark(node: str, capacity_mb: float) -> None:
         )
         esii_inputs[scheme] = inp
         esii_vals.append(compute_esii(inp)["ESII"])
+        mux_metrics[scheme] = compute_ecc_mux_params(scheme)
 
     print(f"Sustainability scores for {node} node (16MB at sea level):")
     for scheme in schemes:
         res = compute_scores(esii_inputs[scheme], esii_reference=esii_vals)
+        latency, energy, area = mux_metrics[scheme]
         print(
-            f"  {scheme}: ESII={res['ESII']:.2f}, NESII={res['NESII']:.2f}, GS={res['GS']:.2f}"
+            f"  {scheme}: ESII={res['ESII']:.2f}, NESII={res['NESII']:.2f}, GS={res['GS']:.2f}" \
+            f", mux latency={latency}, energy={energy}, area={area}"
         )
 
 

--- a/tests/python/test_ecc_mux_params.py
+++ b/tests/python/test_ecc_mux_params.py
@@ -1,0 +1,10 @@
+import pytest
+
+from ecc_mux import compute_ecc_mux_params
+
+
+def test_compute_ecc_mux_params_taec():
+    latency, energy, area = compute_ecc_mux_params("TAEC")
+    assert latency == pytest.approx(0.07)
+    assert energy == pytest.approx(0.03)
+    assert area == pytest.approx(1.4)


### PR DESCRIPTION
## Summary
- add compute_ecc_mux_params helper and expose predefined mux metrics
- print ECC mux latency, energy and area for each scheme in sustainability benchmark
- add regression test for ECC mux parameters

## Testing
- `ruff check ecc_mux.py sram_ecc_benchmark.py tests/python/test_ecc_mux_params.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb0e516758832e81aa177e214eeb98