### PR TITLE
Add altitude-aware flux scaling and expose location controls

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -193,6 +193,9 @@ def main() -> None:
     select_parser.add_argument("--temp", type=float, required=True)
     select_parser.add_argument("--mbu", type=str, default="moderate")
     select_parser.add_argument("--scrub-s", type=float, default=10.0)
+    select_parser.add_argument("--alt-km", type=float, default=0.0)
+    select_parser.add_argument("--latitude", type=float, default=45.0)
+    select_parser.add_argument("--flux-rel", type=float, default=None)
     select_parser.add_argument("--capacity-gib", type=float, required=True)
     select_parser.add_argument("--ci", type=float, required=True)
     select_parser.add_argument("--bitcell-um2", type=float, required=True)
@@ -225,6 +228,9 @@ def main() -> None:
     target_parser.add_argument("--temp", type=float, required=True)
     target_parser.add_argument("--mbu", type=str, default="moderate")
     target_parser.add_argument("--scrub-s", type=float, default=10.0)
+    target_parser.add_argument("--alt-km", type=float, default=0.0)
+    target_parser.add_argument("--latitude", type=float, default=45.0)
+    target_parser.add_argument("--flux-rel", type=float, default=None)
     target_parser.add_argument("--capacity-gib", type=float, required=True)
     target_parser.add_argument("--ci", type=float, required=True)
     target_parser.add_argument("--bitcell-um2", type=float, required=True)
@@ -399,6 +405,9 @@ def main() -> None:
             constraints=constraints,
             mbu=args.mbu,
             scrub_s=args.scrub_s,
+            alt_km=args.alt_km,
+            latitude_deg=args.latitude,
+            flux_rel=args.flux_rel,
             **params,
         )
 
@@ -520,6 +529,9 @@ def main() -> None:
             codes,
             mbu=args.mbu,
             scrub_s=args.scrub_s,
+            alt_km=args.alt_km,
+            latitude_deg=args.latitude,
+            flux_rel=args.flux_rel,
             **params,
         )
 

--- a/tests/python/test_hazucha_cli.py
+++ b/tests/python/test_hazucha_cli.py
@@ -4,8 +4,16 @@ from pathlib import Path
 
 import pytest
 
+from ser_model import flux_from_location
 
-def run_cmd(qcrit: float, flux: float) -> float:
+
+def run_cmd(
+    qcrit: float,
+    *,
+    flux: float | None = None,
+    alt: float = 0.0,
+    latitude: float = 45.0,
+) -> float:
     script = Path(__file__).resolve().parents[2] / "eccsim.py"
     cmd = [
         sys.executable,
@@ -18,19 +26,29 @@ def run_cmd(qcrit: float, flux: float) -> float:
         "0.25",
         "--area",
         "0.08",
-        "--flux-rel",
-        str(flux),
+        "--alt-km",
+        str(alt),
+        "--latitude",
+        str(latitude),
     ]
+    if flux is not None:
+        cmd.extend(["--flux-rel", str(flux)])
     res = subprocess.run(cmd, capture_output=True, text=True, check=True)
     return float(res.stdout.strip().splitlines()[-1])
 
 
 def test_qcrit_and_flux_scaling():
-    base = run_cmd(1.2, 1.0)
-    higher_qcrit = run_cmd(1.3, 1.0)
-    higher_flux = run_cmd(1.2, 2.0)
+    base = run_cmd(1.2)
+    higher_qcrit = run_cmd(1.3)
+    high_alt = run_cmd(1.2, alt=10.0, latitude=60.0)
+    manual_override = run_cmd(1.2, flux=2.0, alt=10.0, latitude=60.0)
 
     assert higher_qcrit < base
-    assert higher_flux > base
-    assert higher_flux == pytest.approx(base * 2.0, rel=1e-3)
+    assert high_alt > base
+
+    base_flux = flux_from_location(0.0, 45.0)
+    scaled_flux = flux_from_location(10.0, 60.0)
+    assert high_alt == pytest.approx(base * (scaled_flux / base_flux), rel=1e-3)
+
+    assert manual_override == pytest.approx(base * 2.0, rel=1e-3)
 

--- a/tests/python/test_reliability_report_cli.py
+++ b/tests/python/test_reliability_report_cli.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from ser_model import HazuchaParams, ser_hazucha
+from ser_model import HazuchaParams, ser_hazucha, flux_from_location
 from fit import compute_fit_pre, compute_fit_post, ecc_coverage_factory, fit_system
 
 
@@ -21,8 +21,10 @@ def test_reliability_report_json():
         "0.25",
         "--area",
         "0.08",
-        "--flux-rel",
-        "1.0",
+        "--alt-km",
+        "2.0",
+        "--latitude",
+        "60.0",
         "--scrub-interval",
         "3600",
         "--capacity-gib",
@@ -41,7 +43,8 @@ def test_reliability_report_json():
     ]
     res = subprocess.run(cmd, capture_output=True, text=True, check=True)
     data = json.loads(res.stdout)
-    hp = HazuchaParams(Qs_fC=0.25, flux_rel=1.0, area_um2=0.08)
+    flux = flux_from_location(2.0, 60.0)
+    hp = HazuchaParams(Qs_fC=0.25, flux_rel=flux, area_um2=0.08)
     fit_bit = ser_hazucha(1.2, hp)
     fit_pre = compute_fit_pre(64, fit_bit, {})
     coverage = ecc_coverage_factory("SEC-DED")
@@ -73,8 +76,10 @@ def test_reliability_report_text():
         "0.25",
         "--area",
         "0.08",
-        "--flux-rel",
-        "1.0",
+        "--alt-km",
+        "2.0",
+        "--latitude",
+        "60.0",
         "--scrub-interval",
         "3600",
         "--capacity-gib",


### PR DESCRIPTION
## Summary
- extend `ser_model.flux_from_location` with an interpolated altitude curve and latitude scaling while retaining the manual override
- plumb altitude, latitude and optional flux overrides through `ecc_selector.select` and the CLI so scenarios can express installation conditions
- exercise the new behaviour through reliability CLI and selector unit tests that verify flux scaling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccee2f4908832eab96114dce4e3a11