### PR TITLE
Fix hypervolume sweep ordering

### DIFF
--- a/analysis/hv.py
+++ b/analysis/hv.py
@@ -39,11 +39,17 @@ def hypervolume(points: Iterable[Sequence[float]], ref: Sequence[float] | None =
     if ref is None:
         ref = (1.0,) * dim
 
-    pts.sort(key=lambda p: p[0])
+    # ``dx`` is accumulated as ``prev - p[0]`` in the sweep below.  When points
+    # are processed in ascending order of the first objective ``dx`` can become
+    # negative (and subsequently shrink the accumulated dominated volume).
+    # Sorting in descending order guarantees ``prev`` is monotonically
+    # decreasing as points are processed, keeping each ``dx`` non-negative.
+    pts.sort(key=lambda p: p[0], reverse=True)
 
     def _hv(slice_pts: list[tuple[float, ...]], r: Sequence[float]) -> float:
         if not slice_pts:
             return 0.0
+        slice_pts = sorted(slice_pts, key=lambda p: p[0], reverse=True)
         prev = r[0]
         vol = 0.0
         for i, p in enumerate(slice_pts):

--- a/tests/python/test_hv_metrics.py
+++ b/tests/python/test_hv_metrics.py
@@ -1,3 +1,5 @@
+import pytest
+
 from analysis.hv import hypervolume, schott_spacing
 
 
@@ -5,6 +7,14 @@ def test_better_frontier_has_higher_hv():
     worse = [(0.6, 0.6)]
     better = [(0.4, 0.4)]
     assert hypervolume(better) > hypervolume(worse)
+
+
+def test_hypervolume_two_point_regression():
+    points = [(0.2, 0.6), (0.6, 0.2)]
+    # The dominated area is the union of the rectangles from each point to
+    # the reference corner ``(1, 1)``.  Analytically, the union area is:
+    #   (0.8 * 0.4) + (0.4 * 0.8) - (0.4 * 0.4) = 0.48
+    assert hypervolume(points) == pytest.approx(0.48)
 
 
 def test_clustered_points_reduce_spacing():


### PR DESCRIPTION
## Summary
- ensure the hypervolume sweep processes points in descending order for every recursive slice
- add a regression test covering a two-point frontier with an analytically known volume

## Testing
- pytest tests/python/test_hv_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68ce8baab76c832ea00dfdfdc71095e9