### PR TITLE
Handle unsupported nodes in reliability report CLI

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -760,11 +760,14 @@ def main() -> None:
             hp = HazuchaParams(
                 Qs_fC=args.qs, flux_rel=flux, area_um2=args.area
             )
-            qcrit = (
-                args.qcrit
-                if args.qcrit is not None
-                else qcrit_lookup("sram6t", args.node_nm, args.vdd, args.tempC, 50)
-            )
+            try:
+                qcrit = (
+                    args.qcrit
+                    if args.qcrit is not None
+                    else qcrit_lookup("sram6t", args.node_nm, args.vdd, args.tempC, 50)
+                )
+            except ValueError as exc:
+                report_parser.error(str(exc))
             fit_bit = ser_hazucha(qcrit, hp)
 
             if args.mbu == "none":

--- a/tests/python/test_reliability_report_cli.py
+++ b/tests/python/test_reliability_report_cli.py
@@ -143,3 +143,29 @@ def test_reliability_report_mbu_effect():
     ded_val = extract_fit_word_post(res_ded.stdout)
     daec_val = extract_fit_word_post(res_daec.stdout)
     assert ded_val > daec_val
+
+
+def test_reliability_report_unknown_node():
+    script = Path(__file__).resolve().parents[2] / "eccsim.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "reliability",
+        "report",
+        "--qs",
+        "0.25",
+        "--area",
+        "0.08",
+        "--node-nm",
+        "16",
+        "--vdd",
+        "0.8",
+        "--tempC",
+        "75",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode != 0
+    assert (
+        "error: Qcrit table for element 'sram6t' has no data for node_nm=16"
+        in res.stderr
+    )


### PR DESCRIPTION
## Summary
- raise a descriptive ValueError when qcrit_lookup is asked for an unsupported node
- surface qcrit lookup failures through the reliability report parser for clearer CLI errors
- add a subprocess-based CLI regression test covering unsupported technology nodes

## Testing
- pytest tests/python/test_reliability_report_cli.py -k "unknown_node"


------
https://chatgpt.com/codex/tasks/task_e_68e209fbeac4832ebb4543073585dd4e