### PR TITLE
Handle UTF-16 JSON inputs in esii CLI

### DIFF
--- a/tests/python/test_esii.py
+++ b/tests/python/test_esii.py
@@ -87,19 +87,21 @@ def test_cli_esii_reports(tmp_path):
     rel = tmp_path / "rel.json"
     energy = tmp_path / "energy.json"
     area = tmp_path / "area.json"
-    json.dump(
-        {
-            "basis": "per_gib",
-            "fit": {"base": 300.0, "ecc": 5.0},
-            "mbu": "moderate",
-            "scrub_s": 10,
-            "node_nm": 14,
-            "vdd": 0.8,
-            "tempC": 75,
-        },
-        open(rel, "w"),
-    )
-    json.dump({"dynamic_J": 2088.0, "leakage_J": 972.0}, open(energy, "w"))
+    with open(rel, "w", encoding="utf-16-le") as fh:
+        json.dump(
+            {
+                "basis": "per_gib",
+                "fit": {"base": 300.0, "ecc": 5.0},
+                "mbu": "moderate",
+                "scrub_s": 10,
+                "node_nm": 14,
+                "vdd": 0.8,
+                "tempC": 75,
+            },
+            fh,
+        )
+    with open(energy, "w", encoding="utf-16-le") as fh:
+        json.dump({"dynamic_J": 2088.0, "leakage_J": 972.0}, fh)
     json.dump({"logic_mm2": 0.1, "macro_mm2": 0.2, "node_nm": 14}, open(area, "w"))
     out = tmp_path / "esii.json"
     cmd = [


### PR DESCRIPTION
## Summary
- add a shared JSON loader that supports UTF-8/16 encodings
- update the esii CLI to use the helper for reliability, energy, and area reports
- extend the esii CLI test to exercise UTF-16 encoded reliability and energy inputs

## Testing
- pytest tests/python/test_esii.py::test_cli_esii_reports

------
https://chatgpt.com/codex/tasks/task_e_68e2103353fc832ebf7b3ccdf8b73be7