### PR TITLE
Add BCH code metadata to ECC selector

### DIFF
--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -59,6 +59,9 @@ _CODE_DB: Dict[str, _CodeInfo] = {
         "SEC-DAEC", parity_bits=9, latency_ns=1.3, area_logic_mm2=1.2
     ),
     "taec-64": _CodeInfo("TAEC", parity_bits=11, latency_ns=1.6, area_logic_mm2=1.5),
+    "bch-63": _CodeInfo(
+        "BCH", parity_bits=12, latency_ns=2.4, area_logic_mm2=2.1, notes="BCH(63,51,2)"
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add a BCH(63,51,2) entry to the ECC selector database with representative parity, latency, and area values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e213964ddc832e922399a414d24927