### PR TITLE
Propagate mux latency into sustainability scores

### DIFF
--- a/sram_ecc_benchmark.py
+++ b/sram_ecc_benchmark.py
@@ -150,8 +150,12 @@ def sustainability_benchmark(capacity_mb: float) -> None:
 
         print(f"Sustainability scores for {node} node (16MB at sea level):")
         for scheme in schemes:
-            res = compute_scores(esii_inputs[scheme], esii_reference=esii_vals)
             latency, energy, area, fanin = mux_metrics[scheme]
+            res = compute_scores(
+                esii_inputs[scheme],
+                latency_ns=latency,
+                esii_reference=esii_vals,
+            )
             print(
                 f"  {scheme}: ESII={res['ESII']:.2f}, NESII={res['NESII']:.2f}, GS={res['GS']:.2f}" \
                 f", mux latency={latency}, energy={energy}, area={area}, mux {fanin}:1"

--- a/tests/python/test_scores.py
+++ b/tests/python/test_scores.py
@@ -34,3 +34,19 @@ def test_compute_scores_matches_components():
     assert 0.0 <= res["NESII"] <= 100.0
     assert res["p5"] == pytest.approx(p5_exp)
     assert res["p95"] == pytest.approx(p95_exp)
+
+
+def test_compute_scores_penalises_latency():
+    inp = ESIIInputs(
+        fit_base=500.0,
+        fit_ecc=50.0,
+        e_dyn=2_000_000.0,
+        e_leak=1_000_000.0,
+        ci_kgco2e_per_kwh=0.3,
+        embodied_kgco2e=2.0,
+    )
+
+    res_fast = compute_scores(inp, latency_ns=0.0)
+    res_slow = compute_scores(inp, latency_ns=5.0)
+
+    assert res_slow["GS"] < res_fast["GS"]


### PR DESCRIPTION
## Summary
- feed the per-scheme multiplexer latency into the sustainability benchmark GS calculation
- extend the compute_scores unit coverage to assert the latency penalty behaviour

## Testing
- pytest tests/python/test_scores.py

------
https://chatgpt.com/codex/tasks/task_e_68e21aa3e824832eafc5b20aa06689e8