### PR TITLE
Add node-aware ECC mux parameters

### DIFF
--- a/ecc_mux.py
+++ b/ecc_mux.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Mapping, Tuple
 
-# Latency in ns, energy in pJ, area in square microns for each ECC scheme.
-_MUX_TABLE: Dict[str, Tuple[float, float, float, int]] = {
+# Base calibration per ECC scheme captured at 28 nm.
+_BASE_MUX_PARAMS: Dict[str, Tuple[float, float, float, int]] = {
     # The fan-in values (final column) capture the effective mux size that the
-    # datapath must steer parity bits through for each ECC topology.  They are
+    # datapath must steer parity bits through for each ECC topology. They are
     # expressed as the number of inputs to a single output (e.g. 2 indicates a
     # 2:1 multiplexer).
     "Hamming_SEC": (0.05, 0.02, 1.0, 2),
@@ -17,17 +17,61 @@ _MUX_TABLE: Dict[str, Tuple[float, float, float, int]] = {
 }
 
 
-def compute_ecc_mux_params(scheme: str) -> Tuple[float, float, float, int]:
-    """Return multiplexer latency, energy, area and fan-in for *scheme*.
+def _scale_mux_params(
+    base: Tuple[float, float, float, int],
+    scaling: Mapping[str, float],
+) -> Tuple[float, float, float, int]:
+    """Return *base* parameters scaled for a particular technology node."""
+
+    latency, energy, area, fanin = base
+    return (
+        latency * scaling["latency"],
+        energy * scaling["energy"],
+        area * scaling["area"],
+        fanin,
+    )
+
+
+_NODE_SCALING: Dict[str, Dict[str, float]] = {
+    "28nm": {"latency": 1.0, "energy": 1.0, "area": 1.0},
+    "16nm": {"latency": 0.85, "energy": 0.8, "area": 0.7},
+    "7nm": {"latency": 0.65, "energy": 0.6, "area": 0.5},
+}
+
+
+# Latency in ns, energy in pJ, area in square microns for each ECC scheme and node.
+_MUX_TABLE: Dict[str, Dict[str, Tuple[float, float, float, int]]] = {
+    scheme: {
+        node: _scale_mux_params(params, node_scaling)
+        for node, node_scaling in _NODE_SCALING.items()
+    }
+    for scheme, params in _BASE_MUX_PARAMS.items()
+}
+
+
+def compute_ecc_mux_params(scheme: str, node: str) -> Tuple[float, float, float, int]:
+    """Return multiplexer latency, energy, area and fan-in for *scheme* and *node*.
 
     Parameters are derived from a simple look-up table and are intended for
     illustrative benchmarking rather than detailed circuit modelling.
     """
 
     try:
-        return _MUX_TABLE[scheme]
+        node_table = _MUX_TABLE[scheme]
     except KeyError as exc:  # pragma: no cover - defensive
-        raise ValueError(f"Unknown scheme: {scheme}") from exc
+        available = ", ".join(sorted(_MUX_TABLE))
+        raise ValueError(
+            f"Unknown scheme: {scheme!r}. Available schemes: {available}"
+        ) from exc
+
+    try:
+        return node_table[node]
+    except KeyError as exc:
+        available_nodes = ", ".join(sorted(node_table))
+        raise ValueError(
+            f"No mux calibration for node {node!r} and scheme {scheme!r}. "
+            f"Available nodes: {available_nodes}"
+        ) from exc
 
 
 __all__ = ["compute_ecc_mux_params"]

--- a/sram_ecc_benchmark.py
+++ b/sram_ecc_benchmark.py
@@ -146,7 +146,7 @@ def sustainability_benchmark(capacity_mb: float) -> None:
             )
             esii_inputs[scheme] = inp
             esii_vals.append(compute_esii(inp)["ESII"])
-            mux_metrics[scheme] = compute_ecc_mux_params(scheme)
+            mux_metrics[scheme] = compute_ecc_mux_params(scheme, node)
 
         print(f"Sustainability scores for {node} node (16MB at sea level):")
         for scheme in schemes:

--- a/tests/python/test_ecc_mux_params.py
+++ b/tests/python/test_ecc_mux_params.py
@@ -3,9 +3,22 @@ import pytest
 from ecc_mux import compute_ecc_mux_params
 
 
-def test_compute_ecc_mux_params_taec():
-    latency, energy, area, fanin = compute_ecc_mux_params("TAEC")
+def test_compute_ecc_mux_params_taec_28nm():
+    latency, energy, area, fanin = compute_ecc_mux_params("TAEC", "28nm")
     assert latency == pytest.approx(0.07)
     assert energy == pytest.approx(0.03)
     assert area == pytest.approx(1.4)
     assert fanin == 8
+
+
+def test_compute_ecc_mux_params_taec_16nm_scaled():
+    latency, energy, area, fanin = compute_ecc_mux_params("TAEC", "16nm")
+    assert latency == pytest.approx(0.07 * 0.85)
+    assert energy == pytest.approx(0.03 * 0.8)
+    assert area == pytest.approx(1.4 * 0.7)
+    assert fanin == 8
+
+
+def test_compute_ecc_mux_params_unknown_node():
+    with pytest.raises(ValueError, match="No mux calibration"):
+        compute_ecc_mux_params("TAEC", "3nm")


### PR DESCRIPTION
## Summary
- represent ECC mux calibration as node-aware lookup tables derived from scalable base parameters
- expose node argument in compute_ecc_mux_params and propagate through the SRAM benchmark utilities
- expand mux parameter tests to exercise node-specific scaling and validation failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e21ab3bbd0832e947e05c0aabfdb0c