### PR TITLE
Add SEC-DAEC and BCH coverage to sustainability benchmark

### DIFF
--- a/ecc_mux.py
+++ b/ecc_mux.py
@@ -11,9 +11,9 @@ _MUX_TABLE: Dict[str, Tuple[float, float, float, int]] = {
     # expressed as the number of inputs to a single output (e.g. 2 indicates a
     # 2:1 multiplexer).
     "Hamming_SEC": (0.05, 0.02, 1.0, 2),
-    "SEC_DED": (0.06, 0.025, 1.2, 4),
+    "SEC_DAEC": (0.065, 0.027, 1.25, 6),
     "TAEC": (0.07, 0.03, 1.4, 8),
-    "DEC": (0.08, 0.035, 1.6, 16),
+    "BCH": (0.09, 0.04, 1.9, 16),
 }
 
 

--- a/tests/python/test_scores.py
+++ b/tests/python/test_scores.py
@@ -34,3 +34,19 @@ def test_compute_scores_matches_components():
     assert 0.0 <= res["NESII"] <= 100.0
     assert res["p5"] == pytest.approx(p5_exp)
     assert res["p95"] == pytest.approx(p95_exp)
+
+
+def test_compute_scores_penalises_latency():
+    inp = ESIIInputs(
+        fit_base=500.0,
+        fit_ecc=50.0,
+        e_dyn=2_000_000.0,
+        e_leak=1_000_000.0,
+        ci_kgco2e_per_kwh=0.3,
+        embodied_kgco2e=2.0,
+    )
+
+    res_fast = compute_scores(inp, latency_ns=0.0)
+    res_slow = compute_scores(inp, latency_ns=5.0)
+
+    assert res_slow["GS"] < res_fast["GS"]


### PR DESCRIPTION
## Summary
- rename the sustainability benchmark inputs to report SEC-DAEC and BCH alongside Hamming-SEC and TAEC
- supply mux latency/energy/area data for SEC-DAEC and BCH so their scores can be produced
- refresh the hybrid ECC guidance to reference the SEC-DAEC outer code

## Testing
- pytest tests/python -q
- python sram_ecc_benchmark.py


------
https://chatgpt.com/codex/tasks/task_e_68e21aa3e824832eafc5b20aa06689e8