### PR TITLE
Thread code-specific word sizes and add Polar code model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ studying how different redundancy schemes behave inside static random-access
 memories (SRAM). It combines:
 
 - **High-performance C++ simulators** that implement concrete Hamming, TAEC and
-  BCH codes under realistic soft-error models.
+  BCH codes under realistic soft-error models, plus polar-code coverage models
+  (64- and 128-bit constructions) grounded in channel polarization theory.
 - **Python analysis tooling** that turns simulation traces into reliability,
   energy and sustainability metrics.
 - **Calibrated data packs** that describe modern technology nodes, operational
@@ -28,7 +29,7 @@ area and sustainability budgets. This repository provides an end-to-end workflow
 for answering those questions:
 
 1. **Model the hardware** – Parameterised C++ simulators emulate different memory
-   organisations, fault models and ECC schemes (Hamming, TAEC, BCH).
+   organisations, fault models and ECC schemes (Hamming, TAEC, BCH, polar).
 2. **Calibrate technology data** – JSON files in `configs/`, `data/` and
    `tech_calib.json` describe device reliability, scrub intervals and energy
    costs.

--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -50,6 +50,7 @@ class _CodeInfo:
     parity_bits: int
     latency_ns: float
     area_logic_mm2: float
+    word_bits: int = 64
     notes: str = ""
 
 
@@ -61,6 +62,30 @@ _CODE_DB: Dict[str, _CodeInfo] = {
     "taec-64": _CodeInfo("TAEC", parity_bits=11, latency_ns=1.6, area_logic_mm2=1.5),
     "bch-63": _CodeInfo(
         "BCH", parity_bits=12, latency_ns=2.4, area_logic_mm2=2.1, notes="BCH(63,51,2)"
+    ),
+    "polar-64-32": _CodeInfo(
+        "POLAR-64-32",
+        parity_bits=32,
+        latency_ns=2.2,
+        area_logic_mm2=2.0,
+        word_bits=64,
+        notes="Polar (N=64, K=32) SC decoder",
+    ),
+    "polar-64-48": _CodeInfo(
+        "POLAR-64-48",
+        parity_bits=16,
+        latency_ns=2.0,
+        area_logic_mm2=1.8,
+        word_bits=64,
+        notes="Polar (N=64, K=48) SC decoder",
+    ),
+    "polar-128-96": _CodeInfo(
+        "POLAR-128-96",
+        parity_bits=32,
+        latency_ns=2.6,
+        area_logic_mm2=2.4,
+        word_bits=128,
+        notes="Polar (N=128, K=96) SC decoder",
     ),
 }
 
@@ -280,24 +305,25 @@ def _compute_metrics(
     hp = HazuchaParams(Qs_fC=0.05, flux_rel=flux, area_um2=area_um2)
     fit_bit = ser_hazucha(qcrit_fC, hp)
 
-    mbu_dist = pmf_adjacent(mbu, word_bits=64, bitline_bits=64)
+    word_bits = info.word_bits
+    mbu_dist = pmf_adjacent(mbu, word_bits=word_bits, bitline_bits=word_bits)
     severity_scale = {"light": 0.0, "moderate": 1.0, "heavy": 5.0}.get(mbu, 1.0)
     # Scale probabilities to FIT rates; the multiplier ensures MBUs have a
     # noticeable impact on the final metric.
     mbu_rates = {
-        k: {kind: fit_bit * 64 * k * p * severity_scale for kind, p in probs.items()}
+        k: {kind: fit_bit * word_bits * k * p * severity_scale for kind, p in probs.items()}
         for k, probs in mbu_dist.items()
     }
 
-    fit_pre = compute_fit_pre(64, fit_bit, mbu_rates)
-    ecc_cov = ecc_coverage_factory(info.family)
-    fit_post = compute_fit_post(64, fit_bit, mbu_rates, ecc_cov, scrub_s)
+    fit_pre = compute_fit_pre(word_bits, fit_bit, mbu_rates)
+    ecc_cov = ecc_coverage_factory(info.family, word_bits=word_bits)
+    fit_post = compute_fit_post(word_bits, fit_bit, mbu_rates, ecc_cov, scrub_s)
 
     fit_base_sys = fit_system(capacity_gib, fit_pre.nominal)
     fit_post_sys = fit_system(capacity_gib, fit_post.nominal)
 
     # --- Energy & Carbon -------------------------------------------------
-    words = capacity_gib * (2**30 * 8) / 64
+    words = capacity_gib * (2**30 * 8) / word_bits
     e_scrub_kwh = scrub_energy_kwh(
         info.parity_bits,
         capacity_gib,
@@ -305,7 +331,7 @@ def _compute_metrics(
         scrub_s,
         node_nm=node,
         vdd=vdd,
-        word_bits=64,
+        word_bits=word_bits,
     )
     e_scrub = e_scrub_kwh * 3_600_000.0
     e_dyn = 0.0
@@ -640,4 +666,3 @@ def select(
 
 
 __all__ = ["select", "_pareto_front", "_nsga2_sort"]
-

--- a/eccsim.py
+++ b/eccsim.py
@@ -148,7 +148,7 @@ def main() -> None:
 
     energy_parser = sub.add_parser("energy", help="Estimate energy use")
     energy_parser.add_argument(
-        "--code", type=str, required=True, choices=["sec-ded", "sec-daec", "taec"]
+        "--code", type=str, required=True, choices=["sec-ded", "sec-daec", "taec", "polar"]
     )
     energy_parser.add_argument("--node", type=float, required=True)
     energy_parser.add_argument("--vdd", type=float, required=True)
@@ -337,7 +337,7 @@ def main() -> None:
         "--ecc",
         type=str,
         default="SEC-DED",
-        choices=["SEC-DED", "SEC-DAEC", "TAEC"],
+        choices=["SEC-DED", "SEC-DAEC", "TAEC", "POLAR", "POLAR-64-32", "POLAR-64-48", "POLAR-128-96"],
     )
     report_parser.add_argument("--scrub-interval", type=float, default=0.0)
     report_parser.add_argument("--capacity-gib", type=float, default=1.0)
@@ -820,7 +820,7 @@ def main() -> None:
                 }
 
             fit_pre = compute_fit_pre(args.word_bits, fit_bit, mbu_rates)
-            coverage = ecc_coverage_factory(args.ecc)
+            coverage = ecc_coverage_factory(args.ecc, word_bits=args.word_bits)
             fit_post = compute_fit_post(
                 args.word_bits, fit_bit, mbu_rates, coverage, args.scrub_interval
             )

--- a/energy_model.py
+++ b/energy_model.py
@@ -233,7 +233,7 @@ def depth_syndrome(bits: int) -> int:
 
 def depth_locator(code: str) -> int:
     """Return adder depth for the locator stage of ``code``."""
-    mapping = {"sec-ded": 1, "sec-daec": 2, "taec": 3}
+    mapping = {"sec-ded": 1, "sec-daec": 2, "taec": 3, "polar": 3}
     try:
         return mapping[code.lower()]
     except KeyError:
@@ -280,7 +280,7 @@ def i_leak_density_A_per_mm2(
     return density_25 * mul * 2 ** ((temp_c - 25.0) / 15.0)
 
 
-_AREA_OVERHEAD = {"sec-ded": 0.1, "sec-daec": 0.12, "taec": 0.15}
+_AREA_OVERHEAD = {"sec-ded": 0.1, "sec-daec": 0.12, "taec": 0.15, "polar": 0.17}
 
 
 def area_overhead_mm2(code: str) -> float:
@@ -312,6 +312,7 @@ _PRIMITIVE_BASE_PER_64: Dict[str, Dict[str, int]] = {
     "sec-ded": {"xor": 100, "and": 50, "adder_stage": 0},
     "sec-daec": {"xor": 120, "and": 60, "adder_stage": 10},
     "taec": {"xor": 150, "and": 70, "adder_stage": 20},
+    "polar": {"xor": 180, "and": 80, "adder_stage": 24},
 }
 
 

--- a/polar.py
+++ b/polar.py
@@ -1,0 +1,120 @@
+"""Polar code utilities grounded in channel polarization theory.
+
+The implementation follows Arikan's construction for a binary symmetric
+channel (BSC).  It computes synthetic-channel Bhattacharyya parameters and
+uses their sum as an upper bound on the successive-cancellation (SC) block
+error probability.  This provides a physics- and math-grounded proxy for
+the probability that a polar code corrects a given error pattern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import math
+from typing import List, Sequence
+
+
+def bhattacharyya_bsc(crossover_p: float) -> float:
+    """Return the Bhattacharyya parameter for a BSC with crossover ``p``."""
+
+    p = min(max(crossover_p, 0.0), 0.5)
+    return 2.0 * math.sqrt(p * (1.0 - p))
+
+
+def _polar_transform(z: float) -> tuple[float, float]:
+    """Return (Z^-, Z^+) for the polarization transform."""
+
+    z_minus = min(1.0, 2.0 * z - z * z)
+    z_plus = z * z
+    return z_minus, z_plus
+
+
+@lru_cache(maxsize=256)
+def synthetic_channel_bhattacharyya(n: int, crossover_p: float) -> List[float]:
+    """Return Bhattacharyya parameters for ``N=2**n`` synthetic channels."""
+
+    z = bhattacharyya_bsc(crossover_p)
+    zs = [z]
+    for _ in range(n):
+        next_zs: List[float] = []
+        for z_val in zs:
+            z_minus, z_plus = _polar_transform(z_val)
+            next_zs.extend((z_minus, z_plus))
+        zs = next_zs
+    return zs
+
+
+def polar_information_indices(
+    n: int, k: int, crossover_p: float
+) -> Sequence[int]:
+    """Return indices of the ``k`` most reliable synthetic channels."""
+
+    if k <= 0:
+        return []
+    if k >= 2**n:
+        return list(range(2**n))
+    zs = synthetic_channel_bhattacharyya(n, crossover_p)
+    ranked = sorted(range(len(zs)), key=lambda idx: zs[idx])
+    return ranked[:k]
+
+
+def polar_block_error_bound(n: int, k: int, crossover_p: float) -> float:
+    """Upper bound on SC block error for a polar (N=2**n, K=k) code."""
+
+    if k <= 0:
+        return 1.0
+    if k >= 2**n:
+        return 0.0
+    zs = synthetic_channel_bhattacharyya(n, crossover_p)
+    info = sorted(zs)[:k]
+    return min(1.0, sum(info))
+
+
+@dataclass(frozen=True)
+class PolarCodeModel:
+    """Polar code proxy model for ECC coverage calculations."""
+
+    n: int
+    k: int
+    adj_correlation: float = 1.35
+    nonadj_correlation: float = 1.0
+
+    @property
+    def n_bits(self) -> int:
+        return 2**self.n
+
+    def effective_crossover(self, k_errors: int, *, word_bits: int, kind: str | None) -> float:
+        """Convert a k-bit upset into an effective BSC crossover probability."""
+
+        if word_bits <= 0:
+            raise ValueError("word_bits must be positive")
+        base = min(0.5, k_errors / float(word_bits))
+        if kind == "adj":
+            return min(0.5, base * self.adj_correlation)
+        return min(0.5, base * self.nonadj_correlation)
+
+    def coverage(self, k_errors: int, *, word_bits: int, kind: str | None) -> float:
+        """Return probability of correct decoding for a k-bit upset pattern."""
+
+        crossover = self.effective_crossover(k_errors, word_bits=word_bits, kind=kind)
+        block_err = polar_block_error_bound(self.n, self.k, crossover)
+        return max(0.0, 1.0 - block_err)
+
+    def info_set(self, crossover_p: float) -> Sequence[int]:
+        """Return frozen/information set selection for the design crossover."""
+
+        return polar_information_indices(self.n, self.k, crossover_p)
+
+
+def polar_catalog() -> List[PolarCodeModel]:
+    """Return a catalog of common polar codes used in this framework."""
+
+    return [
+        PolarCodeModel(n=6, k=32),
+        PolarCodeModel(n=6, k=48),
+        PolarCodeModel(n=7, k=64),
+        PolarCodeModel(n=7, k=96),
+        PolarCodeModel(n=8, k=128),
+        PolarCodeModel(n=8, k=192),
+    ]

--- a/tests/python/test_fit.py
+++ b/tests/python/test_fit.py
@@ -95,3 +95,18 @@ def test_compute_fit_post_uncertainty():
     )
     assert res.nominal == 5.0
     assert res.stddev == 1.0
+
+
+def test_polar_coverage_degrades_with_more_errors():
+    polar = ecc_coverage_factory("POLAR", word_bits=64)
+    cov_single = polar((1, "nonadj"))
+    cov_quad = polar((4, "nonadj"))
+    assert 0.0 <= cov_quad <= cov_single <= 1.0
+
+
+def test_polar_rate_tradeoff():
+    polar_high_rate = ecc_coverage_factory("POLAR-64-48", word_bits=64)
+    polar_low_rate = ecc_coverage_factory("POLAR-64-32", word_bits=64)
+    cov_high = polar_high_rate((2, "nonadj"))
+    cov_low = polar_low_rate((2, "nonadj"))
+    assert cov_low >= cov_high


### PR DESCRIPTION
### Motivation
- Ensure polar code variants (e.g. 128-bit constructions) are modelled with the correct protected word width so FIT/coverage and energy estimates are not mis-sized.
- Provide a lightweight, physics-grounded proxy for polar-code coverage to enable rate/area/energy tradeoff comparisons inside the framework.

### Description
- Add a new `polar.py` implementing `PolarCodeModel`, utilities (`polar_information_indices`, `polar_catalog`) and Bhattacharyya-based block-error bounds for SC decoding.
- Extend `fit.py` to parse `POLAR-<N>-<K>` labels with `_parse_polar_code` and make `ecc_coverage_factory` accept `word_bits` and return polar coverage functions via `PolarCodeModel.coverage`.
- Thread per-code `word_bits` through `ecc_selector.py` by adding `word_bits` to `_CodeInfo`, registering polar entries, using `info.word_bits` for `pmf_adjacent`, FIT aggregation (`compute_fit_pre`/`compute_fit_post`), `ecc_coverage_factory` invocation, word counting and `scrub_energy_kwh` calls, thereby fixing the 128-bit selection issue.
- Update `eccsim.py` CLI to expose polar choices and to pass `word_bits` into coverage when generating reports.
- Update `energy_model.py` to recognize `polar` in `depth_locator`, `_AREA_OVERHEAD`, and `_PRIMITIVE_BASE_PER_64` so energy estimates include conservative polar decoder costs.
- Update docs (`README.md`) to mention polar support and add unit tests in `tests/python/test_fit.py` validating monotonic coverage with more errors and that lower-rate polar codes provide equal-or-better coverage.

### Testing
- Added unit tests in `tests/python/test_fit.py` (`test_polar_coverage_degrades_with_more_errors` and `test_polar_rate_tradeoff`); no automated test run was executed as part of this change, so test status is currently unverified here.
- Recommended command to run the new and existing tests is `pytest tests/python/test_fit.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef9d9745c832eabe3983fb56b7123)