### PR TITLE
Fix ML evaluate fallback-rate overlap counting on top of #166

### DIFF
--- a/ml/evaluate.py
+++ b/ml/evaluate.py
@@ -50,22 +50,24 @@ def evaluate_model(
     probs = clf.predict_proba(X)
     confidences = [float(row.max()) for row in probs]
 
-    ood_count = 0
-    low_conf_count = 0
+    ood_flags: list[bool] = []
+    low_conf_flags: list[bool] = []
     for _, row in X.iterrows():
         feature_row = {k: row[k] for k in CATEGORICAL_FEATURES + NUMERIC_FEATURES}
         max_z, _ = _ood_score(bundle, feature_row)
-        if max_z > ood_max:
-            ood_count += 1
+        ood_flags.append(max_z > ood_max)
     for conf in confidences:
-        if conf < confidence_min:
-            low_conf_count += 1
+        low_conf_flags.append(conf < confidence_min)
+
+    ood_count = sum(ood_flags)
+    low_conf_count = sum(low_conf_flags)
+    fallback_count = sum(ood or low_conf for ood, low_conf in zip(ood_flags, low_conf_flags))
 
     evaluation = {
         "summary": {
             "rows": int(len(df)),
             "policy": policy or "dataset_manifest",
-            "fallback_rate": float((ood_count + low_conf_count) / max(len(df), 1)),
+            "fallback_rate": float(fallback_count / max(len(df), 1)),
             "ood_rate": float(ood_count / max(len(df), 1)),
         },
         "classification": {

--- a/tests/python/test_ml_integration.py
+++ b/tests/python/test_ml_integration.py
@@ -191,3 +191,18 @@ def test_ml_evaluate_smoke():
     assert "classification" in out
     assert "regression" in out
     assert "fallback_breakdown" in out
+
+
+def test_ml_evaluate_fallback_rate_deduplicates_overlap():
+    base = _new_base("eval_fallback_dedupe")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+    eval_dir = base / "eval"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=8, label_policy="fit_min")
+    train_models(dataset_dir, model_dir, seed=8, model_type="linear")
+    artifacts = evaluate_model(dataset_dir, model_dir, eval_dir, policy="fit_min", ood_threshold=-1.0)
+
+    out = json.loads((artifacts["evaluation"]).read_text(encoding="utf-8"))
+    assert out["summary"]["ood_rate"] == 1.0
+    assert out["summary"]["fallback_rate"] <= 1.0


### PR DESCRIPTION
### Motivation
- Prevent overstatement of fallback behavior by ensuring `fallback_rate` counts unique fallback rows (OOD OR low-confidence) instead of summing possibly overlapping counts.

### Description
- Change `evaluate_model` in `ml/evaluate.py` to record per-row boolean flags for OOD and low-confidence, compute `fallback_count` as the union (`ood or low_conf`) and use that for `summary.fallback_rate` while preserving `summary.ood_rate` and the `fallback_breakdown` fields.
- Keep all existing output field names and semantics intact and only adjust the internal metric computation to avoid double-counting.
- Add an integration regression test `test_ml_evaluate_fallback_rate_deduplicates_overlap` in `tests/python/test_ml_integration.py` that forces all rows to be OOD (`ood_threshold=-1.0`) and asserts `ood_rate == 1.0` and `fallback_rate <= 1.0`.

### Testing
- Ran `make` successfully to build project artifacts and native tests. 
- Ran `make test` and `python3 -m pytest -q`; both complete but report 3 pre-existing failures in `tests/python/test_golden_cli_outputs.py` unrelated to this change (golden CLI output differences), so overall test run is failing because of those unrelated golden tests.
- Ran the focused integration test with `python3 -m pytest -q tests/python/test_ml_integration.py -k fallback_rate_deduplicates_overlap` which passed, validating the fix for the fallback-rate deduplication.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa69babf4832ea80293ca7b47c3c8)