### PR TITLE
Guard calibration against low per-class sample counts

### DIFF
--- a/ml/train.py
+++ b/ml/train.py
@@ -128,7 +128,14 @@ def train_models(
         y_energy_train, y_energy_test = y_energy.loc[idx_train], y_energy.loc[idx_test]
 
     clf = _fit_classifier(X_train, y_cls_train, seed=seed, model_type=model_type)
-    if calibrate_confidence in {"isotonic", "platt"} and y_cls_train.nunique() > 1 and len(X_train) >= 10:
+    class_counts = y_cls_train.value_counts()
+    min_class_count = int(class_counts.min()) if len(class_counts) else 0
+    if (
+        calibrate_confidence in {"isotonic", "platt"}
+        and y_cls_train.nunique() > 1
+        and len(X_train) >= 10
+        and min_class_count >= 3
+    ):
         method = "isotonic" if calibrate_confidence == "isotonic" else "sigmoid"
         clf = CalibratedClassifierCV(clf, cv=3, method=method)
         clf.fit(X_train, y_cls_train)

--- a/tests/python/test_ml_integration.py
+++ b/tests/python/test_ml_integration.py
@@ -1,9 +1,11 @@
-﻿import json
+import json
 import math
 import subprocess
 import sys
 import uuid
 from pathlib import Path
+
+import pandas as pd
 
 from ml.dataset import build_dataset
 from ml.evaluate import evaluate_model
@@ -191,3 +193,27 @@ def test_ml_evaluate_smoke():
     assert "classification" in out
     assert "regression" in out
     assert "fallback_breakdown" in out
+
+
+def test_ml_train_calibration_skips_when_class_fold_requirement_not_met():
+    base = _new_base("calibration_class_counts")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=11)
+    dataset_path = dataset_dir / "dataset.csv"
+    df = pd.read_csv(dataset_path)
+
+    code_a = str(df.loc[0, "label_code"])
+
+    subset_a = df[df["label_code"].astype(str) == code_a].head(20).copy()
+    subset_b = df.head(2).copy()
+    subset_b["label_code"] = "synthetic-alt"
+    subset = pd.concat([subset_a, subset_b], ignore_index=True)
+    subset.to_csv(dataset_path, index=False)
+
+    train_models(dataset_dir, model_dir, seed=11, calibrate_confidence="platt")
+
+    pred = predict_with_model(model_dir, _sample_row())
+    assert isinstance(pred["ml_recommendation"], str)
+


### PR DESCRIPTION
### Motivation

- Prevent training-time `ValueError` from `CalibratedClassifierCV(..., cv=3)` when the minority class in the training split has fewer than 3 samples, which caused `ml train --calibrate-confidence {isotonic,platt}` to fail on imbalanced splits.

### Description

- Updated `ml/train.py` to compute `class_counts = y_cls_train.value_counts()` and `min_class_count` and only enable calibration when the minority class has `min_class_count >= 3` in addition to the existing checks (`calibrate_confidence` in `{isotonic,platt}`, at least two classes, and `len(X_train) >= 10`).
- Rewrote the calibration branch to use the guarded condition and to continue using `CalibratedClassifierCV(clf, cv=3, method=...)` only when safe.
- Added an integration test `test_ml_train_calibration_skips_when_class_fold_requirement_not_met` to `tests/python/test_ml_integration.py` that constructs an imbalanced dataset (minority class count < 3), runs `train_models(..., calibrate_confidence='platt')`, and asserts training/prediction complete without raising an error.
- Added `import pandas as pd` to the test file for dataset manipulation.

### Testing

- Ran `make` successfully in the repository and confirmed build steps completed. 
- Ran `make test` and observed the python test suite run; the ML integration tests executed successfully.
- Ran `python3 -m pytest -q` and observed `126 passed, 1 warning` (the warning is from sklearn about a single label in a confusion-matrix case), confirming the new guard and added test pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa694da38832e864dd05ea4f3898a)