### PR TITLE
follow-up: fix README quick-start select/target CLI examples for PR #172

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,10 @@ python3 eccsim.py --help
 
 ```bash
 # Reliability/selection flow
-python3 eccsim.py select --ber 1e-6 --mbu 2 --energy-budget-nj 0.6
+python3 eccsim.py select --codes sec-ded-64,sec-daec-64,taec-64,bch-63 --node 7 --vdd 0.8 --temp 45 --mbu moderate --capacity-gib 16 --ci 400 --bitcell-um2 0.08
 
 # Target-constrained choice (example)
-python3 eccsim.py target --ber 1e-6 --uwer-target 1e-15
+python3 eccsim.py target --codes sec-ded-64,sec-daec-64,taec-64,bch-63 --target-type uwer --target 1e-15 --node 7 --vdd 0.8 --temp 45 --mbu moderate --capacity-gib 16 --ci 400 --bitcell-um2 0.08
 ```
 
 ### 5) Run test suite


### PR DESCRIPTION
### Motivation

- The README quick-start used non-existent flags (`--ber`, `--energy-budget-nj`, `--uwer-target`) which caused the onboarding commands to fail at argparse time. 
- Keep the documented onboarding path runnable and consistent with the existing CLI contract so new users can follow the Quick Start without modifying code.

### Description

- Updated `README.md` to replace the invalid `select` example with a runnable command that uses the required flags: `--codes`, `--node`, `--vdd`, `--temp`, `--mbu`, `--capacity-gib`, `--ci`, and `--bitcell-um2`.
- Updated `README.md` to replace the invalid `target` example with a runnable command that uses `--target-type uwer --target` plus the same required system inputs and `--codes`.
- This is a documentation-only change limited to `README.md` and preserves all CLI behavior and output schemas.

### Testing

- Verified help and argument contracts with `python3 eccsim.py select --help` and `python3 eccsim.py target --help`, which match the updated examples.
- Executed the updated example commands for `select` and `target` and observed successful runs with the provided sample arguments.
- Ran repository checks: `make` succeeded, `make test` (smoke + Python tests) succeeded, and `python3 -m pytest -q` completed with `125 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab055112c8832ebe2902b6ed2b6158)