### PR TITLE
Add ML report-card subcommand for consolidated model artifacts

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -446,6 +446,15 @@ def main() -> None:
     ml_eval.add_argument("--ood-threshold", type=float, default=None)
     ml_eval.add_argument("--json", action="store_true")
 
+    ml_report_card = ml_sub.add_parser("report-card", help="Generate consolidated model report card")
+    ml_report_card.add_argument("--model", type=Path, required=True, help="Model directory")
+    ml_report_card.add_argument(
+        "--out",
+        type=Path,
+        default=Path("model_card.md"),
+        help="Markdown output path (relative paths are resolved from current working directory)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "ml":
@@ -501,6 +510,12 @@ def main() -> None:
             else:
                 for key in ("evaluation",):
                     print(f"{key}: {artifacts[key]}")
+        elif args.ml_command == "report-card":
+            from ml.report_card import generate_report_card
+
+            artifacts = generate_report_card(args.model, args.out)
+            for key in ("report_card",):
+                print(f"{key}: {artifacts[key]}")
         else:
             parser.error("ml subcommand required")
         return
@@ -1095,7 +1110,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
 
 
 

--- a/ml/report_card.py
+++ b/ml/report_card.py
@@ -1,0 +1,73 @@
+"""Model report-card generation for ECC ML artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing required artifact: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _format_md_value(value: Any) -> str:
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def _dict_section(title: str, payload: dict[str, Any]) -> list[str]:
+    lines = [f"## {title}", ""]
+    for key in sorted(payload):
+        lines.append(f"- `{key}`: {_format_md_value(payload[key])}")
+    lines.append("")
+    return lines
+
+
+def generate_report_card(model_dir: Path, out_path: Path) -> dict[str, Path]:
+    """Generate a consolidated markdown report-card from model artifacts.
+
+    Relative output paths are resolved from the current working directory.
+    """
+
+    metrics = _read_json(model_dir / "metrics.json")
+    thresholds = _read_json(model_dir / "thresholds.json")
+    uncertainty = _read_json(model_dir / "uncertainty.json")
+
+    evaluation_path = model_dir / "evaluation.json"
+    evaluation = None
+    if evaluation_path.is_file():
+        evaluation = json.loads(evaluation_path.read_text(encoding="utf-8"))
+
+    resolved_out = out_path if out_path.is_absolute() else (Path.cwd() / out_path)
+    resolved_out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = [
+        "# ECC ML Report Card",
+        "",
+        f"- Model directory: `{model_dir.resolve()}`",
+        f"- Output path contract: relative `--out` paths are resolved from current working directory (`{Path.cwd()}`).",
+        "",
+    ]
+
+    lines.extend(_dict_section("Training Metrics", metrics))
+    lines.extend(_dict_section("Thresholds", thresholds))
+    lines.extend(_dict_section("Uncertainty", uncertainty))
+
+    if evaluation is None:
+        lines.extend(
+            [
+                "## Evaluation",
+                "",
+                "- `status`: evaluation.json not found in model directory",
+                "",
+            ]
+        )
+    else:
+        lines.extend(_dict_section("Evaluation", evaluation))
+
+    resolved_out.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return {"report_card": resolved_out}

--- a/tests/python/test_ml_integration.py
+++ b/tests/python/test_ml_integration.py
@@ -385,3 +385,60 @@ def test_backward_compatible_model_loading_without_feature_lists():
     assert isinstance(pred["ml_recommendation"], str)
     assert "predictions" in pred
 
+
+
+def test_ml_report_card_cli_smoke_and_output_resolution():
+    base = _new_base("report_card")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+    eval_dir = base / "eval"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=13)
+    train_models(dataset_dir, model_dir, seed=13)
+    evaluate_model(dataset_dir, model_dir, eval_dir)
+
+    # report-card reads optional evaluation.json from model directory.
+    (model_dir / "evaluation.json").write_text(
+        (eval_dir / "evaluation.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    out_rel = Path("report_card_from_cli.md")
+    cmd_report = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "ml",
+        "report-card",
+        "--model",
+        str(model_dir),
+        "--out",
+        str(out_rel),
+    ]
+    res = subprocess.run(cmd_report, check=True, capture_output=True, text=True, cwd=base)
+
+    report_path = base / out_rel
+    assert report_path.is_file()
+    assert res.stdout.strip() == f"report_card: {report_path}"
+
+    content = report_path.read_text(encoding="utf-8")
+    assert "# ECC ML Report Card" in content
+    for heading in ("## Training Metrics", "## Thresholds", "## Uncertainty", "## Evaluation"):
+        assert heading in content
+
+
+def test_ml_report_card_requires_core_artifacts():
+    base = _new_base("report_card_missing")
+    model_dir = base / "model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd_report = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "ml",
+        "report-card",
+        "--model",
+        str(model_dir),
+    ]
+    res = subprocess.run(cmd_report, capture_output=True, text=True, cwd=REPO)
+    assert res.returncode != 0
+    assert "Missing required artifact" in (res.stderr + res.stdout)


### PR DESCRIPTION
### Motivation
- Provide an additive CLI to produce a stable, human-readable markdown model report that consolidates ML artifacts for easier inspection and sharing.
- Keep existing behavior and artifacts unchanged while allowing an explicit, backward-compatible report generation step.
- Make output path resolution explicit so users can rely on stable file placement for CI and tooling.

### Description
- Added `ml report-card` subcommand to `eccsim.py` with required `--model` and optional `--out` (default `model_card.md`) and kept it additive to existing ML subcommands.
- Added ML dispatch branch in `eccsim.py` that calls `generate_report_card` and prints a single artifact line `report_card: <path>` to match existing ML command style.
- Implemented `ml/report_card.py` with `generate_report_card(model_dir, out_path)` that reads `metrics.json`, `thresholds.json`, `uncertainty.json`, and optionally `evaluation.json`, emits stable markdown sections and writes the file; relative `--out` paths are resolved from the current working directory and documented in the generated card.
- Added integration tests to `tests/python/test_ml_integration.py` covering CLI smoke/output resolution and missing-artifact failure behavior.

### Testing
- Ran `make` and `make test` with no build/test failures (C++ and smoke steps completed successfully).
- Ran `python3 -m pytest -q` and all Python tests passed; the test run completed with `150 passed, 3 warnings`.
- The new ML integration tests exercised the CLI smoke path, output path resolution, and missing-artifact error and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc6ad4e30832e8d3e2cf7b4cfa138)