### PR TITLE
Fix drift baseline and confidence fallback to avoid false-positive drift detection

### DIFF
--- a/ml/drift.py
+++ b/ml/drift.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -67,16 +68,26 @@ def _reference_numeric_distribution(
     numeric_features: list[str],
     reference_rows: int,
 ) -> dict[str, np.ndarray]:
-    means = bundle.get("train_stats", {}).get("means", {})
-    stds = bundle.get("train_stats", {}).get("stds", {})
+    train_stats = bundle.get("train_stats", {})
+    means = train_stats.get("means", {})
+    stds = train_stats.get("stds", {})
+    reference_numeric = train_stats.get("reference_numeric", {})
     n = max(int(reference_rows), 64)
     ref: dict[str, np.ndarray] = {}
     for feat in numeric_features:
+        raw_values = reference_numeric.get(feat, []) if isinstance(reference_numeric, dict) else []
+        values = np.asarray(raw_values, dtype=float)
+        values = values[np.isfinite(values)]
+        if values.size:
+            ref[feat] = values
+            continue
         mean = float(means.get(feat, 0.0))
         std = float(stds.get(feat, 1.0))
         if not np.isfinite(std) or std <= 0:
             std = 1.0
-        ref[feat] = np.linspace(mean - 1.5 * std, mean + 1.5 * std, n)
+        feat_seed = int(hashlib.sha256(feat.encode("utf-8")).hexdigest()[:8], 16)
+        rng = np.random.default_rng(feat_seed)
+        ref[feat] = rng.normal(loc=mean, scale=std, size=n)
     return ref
 
 
@@ -124,16 +135,38 @@ def compute_drift_report(model_dir: Path, new_data_dir: Path) -> dict[str, Any]:
         ood_scores.append(float(score))
     new_ood_rate = float(np.mean(np.asarray(ood_scores, dtype=float) > ood_threshold)) if ood_scores else 0.0
 
-    reference_ood_rate = float(bundle.get("train_stats", {}).get("reference_ood_rate", 0.0))
+    train_stats = bundle.get("train_stats", {})
+
+    ref_ood_raw = train_stats.get("reference_ood_rate")
+    if ref_ood_raw is None:
+        ref_ood_scores: list[float] = []
+        for i in range(len(X)):
+            feature_row = {k: float(reference_numeric[k][i]) for k in numeric_features}
+            score, _ = _ood_score(
+                bundle,
+                feature_row,
+                method=ood_method,
+                numeric_features=numeric_features,
+            )
+            ref_ood_scores.append(float(score))
+        reference_ood_rate = (
+            float(np.mean(np.asarray(ref_ood_scores, dtype=float) > ood_threshold)) if ref_ood_scores else 0.0
+        )
+    else:
+        reference_ood_rate = float(ref_ood_raw)
     ood_rate_delta = float(new_ood_rate - reference_ood_rate)
 
     classifier = bundle["classifier"]
     probs = classifier.predict_proba(X)
     new_confidence_mean = float(np.mean(np.max(probs, axis=1))) if len(probs) else 0.0
-    reference_confidence_mean = float(
-        bundle.get("train_stats", {}).get("reference_confidence_mean", thresholds["confidence_min"])
-    )
+    ref_conf_raw = train_stats.get("reference_confidence_mean")
+    confidence_baseline_available = ref_conf_raw is not None
+    reference_confidence_mean = float(ref_conf_raw) if confidence_baseline_available else float(new_confidence_mean)
+    if not np.isfinite(reference_confidence_mean):
+        confidence_baseline_available = False
+        reference_confidence_mean = float(new_confidence_mean)
     confidence_shift = float(new_confidence_mean - reference_confidence_mean)
+    confidence_drop = float(max(0.0, -confidence_shift)) if confidence_baseline_available else 0.0
 
     max_psi = float(max(psi_map.values()) if psi_map else 0.0)
     mean_psi = float(np.mean(list(psi_map.values())) if psi_map else 0.0)
@@ -146,12 +179,12 @@ def compute_drift_report(model_dir: Path, new_data_dir: Path) -> dict[str, Any]:
     conf_crit = 0.2
 
     drift_detected = bool(
-        max_psi >= psi_warn or abs(ood_rate_delta) >= ood_warn or abs(confidence_shift) >= conf_warn
+        max_psi >= psi_warn or abs(ood_rate_delta) >= ood_warn or confidence_drop >= conf_warn
     )
     severity = "none"
     if drift_detected:
         severity = "high" if (
-            max_psi >= psi_crit or abs(ood_rate_delta) >= ood_crit or abs(confidence_shift) >= conf_crit
+            max_psi >= psi_crit or abs(ood_rate_delta) >= ood_crit or confidence_drop >= conf_crit
         ) else "medium"
 
     return {

--- a/ml/train.py
+++ b/ml/train.py
@@ -339,9 +339,14 @@ def train_models(
     if numeric_features:
         means = _as_float_dict(X_train[numeric_features].mean())
         stds = _as_float_dict(X_train[numeric_features].std(ddof=0).replace(0, 1.0))
+        reference_numeric = {
+            feat: [float(v) for v in X_train[feat].to_numpy(dtype=float).tolist()]
+            for feat in numeric_features
+        }
     else:
         means = {}
         stds = {}
+        reference_numeric = {}
 
     confidence_threshold = 0.6
     if acc < 0.5:
@@ -394,6 +399,24 @@ def train_models(
         seed=seed,
     )
 
+    train_ood_scores: list[float] = []
+    for _, row in X_train[numeric_features].iterrows():
+        feature_row = {k: float(row[k]) for k in numeric_features}
+        score, _ = _ood_score(
+            bundle_stub,
+            feature_row,
+            method=str(ood_payload.get("method", "zscore")),
+            numeric_features=numeric_features,
+        )
+        train_ood_scores.append(float(score))
+    reference_ood_rate = (
+        float(np.mean(np.asarray(train_ood_scores, dtype=float) > float(ood_threshold)))
+        if train_ood_scores
+        else 0.0
+    )
+
+    reference_confidence_mean = float(np.mean(confidences)) if confidences.size else 0.0
+
     thresholds = {
         "confidence_min": float(confidence_threshold),
         "ood_max_abs_z": float(ood_threshold),
@@ -443,6 +466,9 @@ def train_models(
         "train_stats": {
             "means": means,
             "stds": stds,
+            "reference_numeric": reference_numeric,
+            "reference_ood_rate": float(reference_ood_rate),
+            "reference_confidence_mean": float(reference_confidence_mean),
             "train_size": int(len(X_train)),
             "test_size": int(len(X_test)),
         },

--- a/tests/python/test_ml_integration.py
+++ b/tests/python/test_ml_integration.py
@@ -426,7 +426,41 @@ def test_ml_check_drift_cli_writes_stable_report():
     assert isinstance(payload["summary"]["max_psi"], float)
     assert isinstance(payload["status"]["drift_detected"], bool)
     assert payload["status"]["severity"] in {"none", "medium", "high"}
+    assert payload["status"]["drift_detected"] is False
+    assert payload["status"]["severity"] == "none"
 
+
+
+def test_ml_check_drift_missing_reference_confidence_baseline_is_neutral():
+    base = _new_base("drift_conf_baseline")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=10)
+    train_models(dataset_dir, model_dir, seed=10)
+
+    bundle = joblib.load(model_dir / "model.joblib")
+    bundle.setdefault("train_stats", {}).pop("reference_confidence_mean", None)
+    joblib.dump(bundle, model_dir / "model.joblib")
+
+    out_path = base / "drift_no_ref_conf.json"
+    cmd = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "ml",
+        "check-drift",
+        "--model",
+        str(model_dir),
+        "--new-data",
+        str(dataset_dir),
+        "--out",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=REPO)
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert math.isclose(float(payload["confidence_shift"]), 0.0, abs_tol=1e-12)
+    assert payload["status"]["drift_detected"] is False
 
 def test_ml_check_drift_fail_on_drift_exits_nonzero():
     base = _new_base("drift_fail")


### PR DESCRIPTION
### Motivation
- The PSI baseline was synthesized as a uniform linspace and produced unstable PSI on unchanged data, causing persistent false-positive drift flags.
- The drift logic fell back to a policy cutoff (`confidence_min`) when `reference_confidence_mean` was absent, which can incorrectly mark healthy models as drifted.

### Description
- Train-time artifacts now include `train_stats.reference_numeric`, `train_stats.reference_ood_rate`, and `train_stats.reference_confidence_mean` so drift checks can use real training distributions and summaries.
- `ml/drift.py` now derives numeric PSI from stored `reference_numeric` when present and only falls back to a deterministic Gaussian sample (seeded per-feature) for legacy artifacts.
- `ml/drift.py` computes a fallback `reference_ood_rate` from the reference distribution if the artifact is missing it, and changes confidence handling to treat missing `reference_confidence_mean` as neutral (use `new_confidence_mean` as baseline) and only consider confidence *drops* when a true baseline exists.
- Updated `tests/python/test_ml_integration.py` to assert same-distribution drift checks do not report drift and added a regression test ensuring missing `reference_confidence_mean` is neutral and does not trigger drift.

### Testing
- Ran targeted drift tests: `python3 -m pytest -q tests/python/test_ml_integration.py -k 'drift'` and the drift-related tests passed (3 passed, 16 deselected). 
- Ran full test matrix: `make`, `make test`, and `python3 -m pytest -q` which completed successfully with the Python test suite reporting `153 passed, 3 warnings`.
- Verified the updated integration tests for neutral same-distribution behavior and missing confidence baseline passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdef5e8f4832ea54307c53e942859)