### PR TITLE
Add centralized output sanity checks with optional strict enforcement

### DIFF
--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -749,6 +749,11 @@ def _selector_args_parser() -> argparse.ArgumentParser:
         default=None,
     )
     parser.add_argument("--ml-debug", action="store_true", help="Emit JSON-only ML diagnostics")
+    parser.add_argument(
+        "--strict-sanity",
+        action="store_true",
+        help="Hard-fail when sanity checks detect implausible predictions",
+    )
 
     return parser
 
@@ -940,6 +945,7 @@ def _run_ml_advisory(args: argparse.Namespace) -> dict[str, object]:
             confidence_min_override=args.ml_confidence_min,
             ood_threshold_override=args.ml_ood_max,
             policy_override=args.ml_policy,
+            strict_sanity=args.strict_sanity,
         )
 
         reasons: list[str] = []
@@ -957,6 +963,10 @@ def _run_ml_advisory(args: argparse.Namespace) -> dict[str, object]:
             "predictions": pred.get("predictions", {}),
             "prediction_set": pred.get("prediction_set"),
         }
+        sanity_warnings = list(pred.get("sanity_warnings", []))
+        if sanity_warnings:
+            candidate_diag["sanity_warnings"] = sanity_warnings
+
         if reasons:
             candidate_diag["reasons"] = reasons
             rejected_entries.append(candidate_diag)

--- a/eccsim.py
+++ b/eccsim.py
@@ -36,6 +36,7 @@ from fit import (
     FitEstimate,
 )
 from energy_model import UncertaintyValidationError, energy_report
+from validation.output_sanity import OutputSanityError
 from ecc_selector import select
 
 
@@ -190,6 +191,11 @@ def main() -> None:
         type=float,
         default=0.25,
         help="Maximum allowed relative stddev for strict validation",
+    )
+    energy_parser.add_argument(
+        "--strict-sanity",
+        action="store_true",
+        help="Hard-fail when output sanity checks detect implausible values",
     )
 
     carbon_parser = sub.add_parser("carbon", help="Estimate carbon footprint")
@@ -1035,8 +1041,9 @@ def main() -> None:
                 include_confidence=args.uncertainty_path is not None,
                 strict_validation=args.strict_validation,
                 max_relative_stddev=args.max_relative_stddev,
+                strict_sanity=args.strict_sanity,
             )
-        except UncertaintyValidationError as exc:
+        except (UncertaintyValidationError, OutputSanityError) as exc:
             energy_parser.error(str(exc))
         if args.report == "json":
             json.dump(result, sys.stdout)
@@ -1045,6 +1052,8 @@ def main() -> None:
             print(f"{'Dynamic (J)':<15} {result['dynamic_J']:.3e}")
             print(f"{'Leakage (J)':<15} {result['leakage_J']:.3e}")
             print(f"{'Total (J)':<15} {result['total_J']:.3e}")
+        for warning in result.get("sanity_warnings", []):
+            print(f"warning: {warning}", file=sys.stderr)
         return
 
     if args.command == "reliability":

--- a/energy_model.py
+++ b/energy_model.py
@@ -18,6 +18,11 @@ import numpy as np
 import math
 
 from calibration import load_calibration as _load_calib
+from validation.output_sanity import (
+    enforce_sanity,
+    validate_metric_non_negative,
+    validate_operating_point,
+)
 
 
 _CALIB = _load_calib(Path(__file__).with_name("tech_calib.json"))
@@ -521,10 +526,28 @@ def energy_report(
     include_confidence: bool = False,
     strict_validation: bool = False,
     max_relative_stddev: float = 0.25,
+    strict_sanity: bool = False,
 ) -> Dict[str, float]:
     dyn = dynamic_energy_j(ops, code, node_nm, vdd, word_bits=word_bits, mode=mode)
     leak = leakage_energy_j(vdd, node_nm, temp_c, code, lifetime_h, corner=corner)
     result = {"dynamic_J": dyn, "leakage_J": leak, "total_J": dyn + leak}
+    sanity_warnings = []
+    sanity_warnings.extend(
+        validate_operating_point(
+            _CALIB,
+            node_nm=node_nm,
+            vdd=vdd,
+        )
+    )
+    sanity_warnings.extend(
+        validate_metric_non_negative(
+            {"dynamic_J": dyn, "leakage_J": leak, "total_J": dyn + leak},
+            context={"node": node_nm, "vdd": vdd, "gate": code},
+        )
+    )
+    enforce_sanity(sanity_warnings, strict=strict_sanity)
+    if sanity_warnings:
+        result["sanity_warnings"] = sanity_warnings
     if include_confidence or strict_validation:
         if uncertainty_path is None:
             if strict_validation:

--- a/ml/predict.py
+++ b/ml/predict.py
@@ -16,6 +16,10 @@ from .features import (
     row_to_feature_dict,
 )
 from .model_registry import load_model_bundle as _load_model_bundle
+from validation.output_sanity import (
+    enforce_sanity,
+    validate_metric_non_negative,
+)
 
 
 DEFAULT_THRESHOLDS: dict[str, float | str] = {
@@ -191,6 +195,7 @@ def predict_with_model(
     confidence_min_override: float | None = None,
     ood_threshold_override: float | None = None,
     policy_override: str | None = None,
+    strict_sanity: bool = False,
 ) -> dict[str, object]:
     """Predict recommended code and reliability/energy/carbon metrics."""
 
@@ -221,6 +226,19 @@ def predict_with_model(
     pred_fit = float(reg_fit.predict(X)[0])
     pred_carbon = float(reg_carbon.predict(X)[0])
     pred_energy = float(reg_energy.predict(X)[0])
+
+    sanity_warnings = validate_metric_non_negative(
+        {
+            "FIT": pred_fit,
+            "carbon_kg": pred_carbon,
+            "energy_kWh": pred_energy,
+        },
+        context={
+            "node": row.get("node", "unknown"),
+            "vdd": row.get("vdd", "unknown"),
+        },
+    )
+    enforce_sanity(sanity_warnings, strict=strict_sanity)
 
     thresholds = resolve_thresholds(
         bundle.get("thresholds", {}),
@@ -275,6 +293,7 @@ def predict_with_model(
         "prediction_set": prediction_set,
         "selected_policy": str(thresholds["ml_policy"]),
         "thresholds_used": thresholds,
+        "sanity_warnings": sanity_warnings,
     }
 
 

--- a/tests/fixtures/golden/energy_sanity_strict_error.txt
+++ b/tests/fixtures/golden/energy_sanity_strict_error.txt
@@ -1,0 +1,1 @@
+energy < 0 for metric=dynamic_J, value=-7e-10, gate=sec-ded, node=7.0, vdd=0.8

--- a/tests/fixtures/golden/energy_sanity_warning.stderr.txt
+++ b/tests/fixtures/golden/energy_sanity_warning.stderr.txt
@@ -1,0 +1,1 @@
+warning: energy < 0 for metric=dynamic_J, value=-7e-10, gate=sec-ded, node=7.0, vdd=0.8

--- a/tests/python/test_golden_cli_outputs.py
+++ b/tests/python/test_golden_cli_outputs.py
@@ -1,4 +1,4 @@
-﻿import csv
+import csv
 import json
 import math
 import subprocess
@@ -215,3 +215,49 @@ def test_golden_legacy_ecc_selector_cli():
     res = _run(cmd)
     assert res.stdout == (FIXTURES / "ecc_selector_legacy.stdout.txt").read_text(encoding="utf-8")
     assert res.stderr == (FIXTURES / "ecc_selector_legacy.stderr.txt").read_text(encoding="utf-8")
+
+
+def test_golden_energy_sanity_warning_text():
+    cmd = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "energy",
+        "--code",
+        "sec-ded",
+        "--node",
+        "7",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ops",
+        "-5",
+        "--lifetime-h",
+        "10",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO, check=True)
+    assert res.stderr == (FIXTURES / "energy_sanity_warning.stderr.txt").read_text(encoding="utf-8")
+
+
+def test_golden_energy_sanity_strict_error_text():
+    cmd = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "energy",
+        "--code",
+        "sec-ded",
+        "--node",
+        "7",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ops",
+        "-5",
+        "--lifetime-h",
+        "10",
+        "--strict-sanity",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO, check=False)
+    assert res.returncode == 2
+    assert (FIXTURES / "energy_sanity_strict_error.txt").read_text(encoding="utf-8") in res.stderr

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation helpers for output sanity checks."""

--- a/validation/output_sanity.py
+++ b/validation/output_sanity.py
@@ -1,0 +1,135 @@
+"""Centralized output sanity checks for energy and prediction flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SanityIssue:
+    """Human-readable sanity issue."""
+
+    message: str
+
+
+class OutputSanityError(ValueError):
+    """Raised when strict sanity mode is enabled and issues are detected."""
+
+
+def _interp_gate(calib: Mapping[int, Mapping[float, Mapping[str, Mapping[str, float]]]], node_nm: float, vdd: float, gate: str) -> float:
+    nodes = np.array(sorted(int(k) for k in calib.keys()), dtype=float)
+    per_node = []
+    for node in nodes:
+        table = calib[int(node)]
+        vols = np.array(sorted(float(k) for k in table.keys()), dtype=float)
+        vals = np.array([float(table[float(vol)]["gates"][gate]) for vol in vols], dtype=float)
+        per_node.append(float(np.interp(vdd, vols, vals)))
+    return float(np.interp(node_nm, nodes, np.array(per_node, dtype=float)))
+
+
+def _nearest_nodes(calib: Mapping[int, Mapping[float, Mapping[str, Mapping[str, float]]]], node_nm: float) -> list[int]:
+    nodes = sorted(int(k) for k in calib.keys())
+    if not nodes:
+        return []
+    if node_nm <= nodes[0]:
+        return [nodes[0]]
+    if node_nm >= nodes[-1]:
+        return [nodes[-1]]
+    below = max(n for n in nodes if n <= node_nm)
+    above = min(n for n in nodes if n >= node_nm)
+    return sorted({below, above})
+
+
+def validate_operating_point(
+    calib: Mapping[int, Mapping[float, Mapping[str, Mapping[str, float]]]],
+    *,
+    node_nm: float,
+    vdd: float,
+    max_delta_ratio: float = 1.0,
+) -> list[str]:
+    """Validate interpolated gate energies around an operating point."""
+
+    issues: list[str] = []
+    gates = ("xor", "and", "adder_stage")
+    energies = {gate: _interp_gate(calib, node_nm, vdd, gate) for gate in gates}
+
+    for gate, energy in energies.items():
+        if energy < 0.0:
+            issues.append(f"energy < 0 for node={node_nm:g}, vdd={vdd:g}, gate={gate}")
+
+    xor_energy = energies["xor"]
+    if xor_energy > 0.0:
+        and_ratio = energies["and"] / xor_energy
+        if not (0.2 <= and_ratio <= 1.2):
+            issues.append(
+                f"ratio out of bounds for node={node_nm:g}, vdd={vdd:g}, ratio=and/xor, value={and_ratio:.6g}, expected=[0.2,1.2]"
+            )
+        adder_ratio = energies["adder_stage"] / xor_energy
+        if not (1.0 <= adder_ratio <= 3.0):
+            issues.append(
+                f"ratio out of bounds for node={node_nm:g}, vdd={vdd:g}, ratio=adder_stage/xor, value={adder_ratio:.6g}, expected=[1.0,3.0]"
+            )
+
+    # Monotonic trend check along VDD for the nearest characterization node(s).
+    for node in _nearest_nodes(calib, node_nm):
+        table = calib[int(node)]
+        vols = sorted(float(k) for k in table.keys())
+        for gate in gates:
+            for lo, hi in zip(vols, vols[1:]):
+                e_lo = float(table[lo]["gates"][gate])
+                e_hi = float(table[hi]["gates"][gate])
+                if e_hi + 1e-18 < e_lo:
+                    issues.append(
+                        f"non-monotonic trend for node={node:g}, gate={gate}: energy decreases from vdd={lo:g} ({e_lo:.6g}) to vdd={hi:g} ({e_hi:.6g})"
+                    )
+
+    # Plausible local delta check around nearby operating points.
+    for gate, energy in energies.items():
+        refs: list[tuple[float, float, str]] = []
+        for node in _nearest_nodes(calib, node_nm):
+            table = calib[int(node)]
+            vols = sorted(float(k) for k in table.keys())
+            near_v = min(vols, key=lambda x: abs(x - vdd))
+            refs.append((float(table[near_v]["gates"][gate]), node, near_v))
+        for ref, ref_node, ref_vdd in refs:
+            denom = max(abs(ref), 1e-18)
+            delta = abs(energy - ref) / denom
+            if delta > max_delta_ratio:
+                issues.append(
+                    f"delta too large for node={node_nm:g}, vdd={vdd:g}, gate={gate}: relative_delta={delta:.6g} vs nearby node={ref_node:g}, vdd={ref_vdd:g}"
+                )
+
+    return issues
+
+
+def validate_metric_non_negative(metrics: Mapping[str, float], *, context: Mapping[str, object]) -> list[str]:
+    """Validate non-negative numeric output metrics."""
+
+    issues: list[str] = []
+    context_bits = [f"{k}={context[k]}" for k in sorted(context)]
+    context_text = ", ".join(context_bits)
+    for key, value in metrics.items():
+        try:
+            as_float = float(value)
+        except (TypeError, ValueError):
+            continue
+        if as_float < 0.0:
+            issues.append(f"energy < 0 for metric={key}, value={as_float:.6g}, {context_text}")
+    return issues
+
+
+def enforce_sanity(issues: list[str], *, strict: bool) -> None:
+    if issues and strict:
+        raise OutputSanityError("; ".join(issues))
+
+
+__all__ = [
+    "OutputSanityError",
+    "SanityIssue",
+    "enforce_sanity",
+    "validate_metric_non_negative",
+    "validate_operating_point",
+]


### PR DESCRIPTION
### Motivation
- Provide a single place for human-readable, actionable sanity checks on energy and ML prediction outputs to catch implausible values early.
- Allow operators to observe non-breaking warnings by default while enabling an opt-in hard-fail mode for CI/strict workflows.

### Description
- Add `validation/output_sanity.py` implementing checks for non-negative energies, monotonic VDD trends, bounded gate-energy ratios (`and/xor`, `adder_stage/xor`), and local delta plausibility, and `OutputSanityError` for strict failures.
- Integrate checks into `energy_model.energy_report(...)` so energy reports include `sanity_warnings` by default and accept `strict_sanity=True` to raise `OutputSanityError`. 
- Integrate checks into `ml.predict.predict_with_model(...)` so ML predictions emit `sanity_warnings` and accept `strict_sanity=True` to hard-fail. 
- Expose `--strict-sanity` CLI option in `eccsim.py` (energy command) and `ecc_selector.py` (ML selector) and surface warning-mode text on stderr in a literal, stable, human-readable format.
- Add golden tests and fixtures to lock warning/error text stability: `test_golden_energy_sanity_warning_text` and `test_golden_energy_sanity_strict_error_text` plus corresponding fixture files.

### Testing
- Ran `make` which completed successfully (compilation and smoke tests passed). 
- Ran `make test` / `python3 -m pytest -q` which reported 4 pre-existing ML lifecycle/drift/report-card test failures unrelated to the sanity validator changes; other tests passed (164 passed, 4 failed, 3 warnings). 
- Ran targeted golden checks `python3 -m pytest -q tests/python/test_golden_cli_outputs.py -k sanity` which passed and verified the exact warning and strict-error text output. 
- Manually exercised `eccsim.py energy` with and without `--strict-sanity` to confirm warning-mode prints to stderr and strict-mode exits with an error message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3af9e828832ea12b8cb38b493268)