### PR TITLE
Add deterministic ML dataset splits and holdout signoff evaluation

### DIFF
--- a/config/signoff_thresholds.json
+++ b/config/signoff_thresholds.json
@@ -1,0 +1,25 @@
+{
+  "overall": {
+    "fit_true": {
+      "mae": 50000000000.0,
+      "mape_pct": 35.0,
+      "rmse": 110000000000.0
+    },
+    "carbon_true": {
+      "mae": 1200.0,
+      "mape_pct": 12.0,
+      "rmse": 1800.0
+    },
+    "energy_true": {
+      "mae": 3200.0,
+      "mape_pct": 14.0,
+      "rmse": 4500.0
+    }
+  },
+  "worst_bin": {
+    "max_fit_mae": 90000000000.0
+  },
+  "bias": {
+    "max_abs_mean_error": 25000000000.0
+  }
+}

--- a/eccsim.py
+++ b/eccsim.py
@@ -450,6 +450,15 @@ def main() -> None:
         help="Repeatable optional feature disable list",
     )
 
+    ml_split = ml_sub.add_parser("split-dataset", help="Create deterministic ML train/validation/holdout splits")
+    ml_split.add_argument("--dataset", type=Path, required=True, help="Dataset directory")
+    ml_split.add_argument("--out", type=Path, default=None, help="Optional split output file (default: <dataset>/dataset_splits.json)")
+    ml_split.add_argument("--seed", type=int, default=1)
+    ml_split.add_argument("--train-ratio", type=float, default=0.7)
+    ml_split.add_argument("--validation-ratio", type=float, default=0.15)
+    ml_split.add_argument("--holdout-ratio", type=float, default=0.15)
+    ml_split.add_argument("--group-column", default="scenario_hash")
+
     ml_train = ml_sub.add_parser("train", help="Train ML advisory model")
     ml_train.add_argument("--dataset", type=Path, required=True, help="Dataset directory")
     ml_train.add_argument("--model-out", type=Path, required=True)
@@ -467,6 +476,9 @@ def main() -> None:
     ml_eval.add_argument("--out", type=Path, required=True, help="Evaluation output directory")
     ml_eval.add_argument("--policy", choices=["carbon_min", "fit_min", "energy_min", "utility_balanced"], default=None)
     ml_eval.add_argument("--ood-threshold", type=float, default=None)
+    ml_eval.add_argument("--split", choices=["all", "train", "validation", "holdout"], default="all")
+    ml_eval.add_argument("--signoff-thresholds", type=Path, default=None)
+    ml_eval.add_argument("--strict-signoff", action="store_true")
     ml_eval.add_argument("--json", action="store_true")
 
     ml_drift = ml_sub.add_parser("check-drift", help="Compute ML data drift report")
@@ -507,6 +519,19 @@ def main() -> None:
                 parser.error(str(exc))
             for key in ("dataset", "schema", "manifest"):
                 print(f"{key}: {artifacts[key]}")
+        elif args.ml_command == "split-dataset":
+            from ml.splits import create_deterministic_splits
+
+            split_path = create_deterministic_splits(
+                args.dataset,
+                args.out,
+                seed=args.seed,
+                train_ratio=args.train_ratio,
+                validation_ratio=args.validation_ratio,
+                holdout_ratio=args.holdout_ratio,
+                group_column=args.group_column,
+            )
+            print(f"splits: {split_path}")
         elif args.ml_command == "train":
             from ml.train import train_models
 
@@ -532,12 +557,16 @@ def main() -> None:
                 args.out,
                 policy=args.policy,
                 ood_threshold=args.ood_threshold,
+                split=args.split,
+                signoff_thresholds=args.signoff_thresholds,
+                strict_signoff=args.strict_signoff,
             )
             if args.json:
                 print(json.dumps({k: str(v) for k, v in artifacts.items()}, indent=2, sort_keys=True))
             else:
-                for key in ("evaluation",):
-                    print(f"{key}: {artifacts[key]}")
+                for key in ("evaluation", "holdout_report", "signoff"):
+                    if key in artifacts:
+                        print(f"{key}: {artifacts[key]}")
         elif args.ml_command == "check-drift":
             from ml.drift import check_drift
 

--- a/ml/evaluate.py
+++ b/ml/evaluate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +14,135 @@ from .model_registry import load_model_bundle
 from .predict import _ood_score, resolve_thresholds
 
 
+TARGET_TO_PRED = {
+    "fit_true": "fit",
+    "carbon_true": "carbon",
+    "energy_true": "energy",
+}
+
+
+def _safe_mape(y_true: pd.Series, y_pred: pd.Series) -> float:
+    eps = 1e-12
+    denom = y_true.abs() > eps
+    if int(denom.sum()) == 0:
+        return 0.0
+    pct = ((y_true[denom] - y_pred[denom]).abs() / y_true[denom].abs()) * 100.0
+    return float(pct.mean())
+
+
+def _safe_rmse(y_true: pd.Series, y_pred: pd.Series) -> float:
+    if len(y_true) == 0:
+        return 0.0
+    sq = ((y_true - y_pred) ** 2).mean()
+    return float(math.sqrt(float(sq)))
+
+
+def _calc_target_metrics(df: pd.DataFrame, target: str, pred_col: str) -> dict[str, float]:
+    y_true = df[target].astype(float)
+    y_pred = df[pred_col].astype(float)
+    err = y_pred - y_true
+    mae = float(mean_absolute_error(y_true, y_pred)) if len(df) else 0.0
+    return {
+        "mae": mae,
+        "mape_pct": _safe_mape(y_true, y_pred),
+        "rmse": _safe_rmse(y_true, y_pred),
+        "mean_error": float(err.mean()) if len(df) else 0.0,
+        "mean_percentage_error_pct": float((((err) / y_true.replace(0.0, pd.NA)).dropna() * 100.0).mean()) if len(df) else 0.0,
+    }
+
+
+def _worst_bin_metrics(df: pd.DataFrame, *, target: str, pred_col: str) -> dict[str, dict[str, object]]:
+    if len(df) == 0:
+        return {
+            "node": {"bin": None, "mae": 0.0, "rows": 0},
+            "vdd": {"bin": None, "mae": 0.0, "rows": 0},
+            "temp": {"bin": None, "mae": 0.0, "rows": 0},
+            "gate": {"bin": None, "mae": 0.0, "rows": 0},
+        }
+
+    def worst_for(col: str) -> dict[str, object]:
+        grouped = []
+        for bin_value, g in df.groupby(col):
+            mae = float(mean_absolute_error(g[target].astype(float), g[pred_col].astype(float)))
+            grouped.append((mae, str(bin_value), int(len(g))))
+        grouped.sort(reverse=True)
+        top = grouped[0]
+        return {"bin": top[1], "mae": top[0], "rows": top[2]}
+
+    return {
+        "node": worst_for("node"),
+        "vdd": worst_for("vdd"),
+        "temp": worst_for("temp"),
+        "gate": worst_for("code"),
+    }
+
+
+def _select_eval_rows(df: pd.DataFrame, dataset_dir: Path, split: str) -> pd.DataFrame:
+    if split == "all":
+        return df.copy()
+
+    split_path = dataset_dir / "dataset_splits.json"
+    if not split_path.is_file():
+        raise FileNotFoundError(
+            f"Missing split file: {split_path}. Run `eccsim.py ml split-dataset --dataset {dataset_dir}` first."
+        )
+    payload = json.loads(split_path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", {}).get(split)
+    if not isinstance(rows, list):
+        raise ValueError(f"Split {split!r} not found in {split_path}")
+    return df.iloc[rows].reset_index(drop=True)
+
+
+def _evaluate_thresholds(holdout: dict[str, object], thresholds: dict[str, object]) -> dict[str, object]:
+    checks: list[dict[str, object]] = []
+    for target_key, target_thresholds in thresholds.get("overall", {}).items():
+        observed = holdout["overall"].get(target_key, {})
+        for metric_key, limit in target_thresholds.items():
+            val = float(observed.get(metric_key, 0.0))
+            lim = float(limit)
+            checks.append(
+                {
+                    "metric": f"overall.{target_key}.{metric_key}",
+                    "value": val,
+                    "limit": lim,
+                    "pass": val <= lim,
+                }
+            )
+
+    bias_limit = thresholds.get("bias", {}).get("max_abs_mean_error")
+    if bias_limit is not None:
+        lim = float(bias_limit)
+        for target_key, observed in holdout["bias"].items():
+            val = abs(float(observed.get("mean_error", 0.0)))
+            checks.append(
+                {
+                    "metric": f"bias.{target_key}.abs_mean_error",
+                    "value": val,
+                    "limit": lim,
+                    "pass": val <= lim,
+                }
+            )
+
+    worst_fit_limit = thresholds.get("worst_bin", {}).get("max_fit_mae")
+    if worst_fit_limit is not None:
+        lim = float(worst_fit_limit)
+        for axis, observed in holdout["worst_bin_error"].items():
+            val = float(observed.get("mae", 0.0))
+            checks.append(
+                {
+                    "metric": f"worst_bin_error.{axis}.mae",
+                    "value": val,
+                    "limit": lim,
+                    "pass": val <= lim,
+                }
+            )
+
+    return {
+        "pass": bool(all(bool(c["pass"]) for c in checks)),
+        "checks": checks,
+    }
+
+
 def evaluate_model(
     dataset_dir: Path,
     model_dir: Path,
@@ -20,6 +150,9 @@ def evaluate_model(
     *,
     policy: str | None = None,
     ood_threshold: float | None = None,
+    split: str = "all",
+    signoff_thresholds: Path | None = None,
+    strict_signoff: bool = False,
 ) -> dict[str, Path]:
     dataset_path = dataset_dir / "dataset.csv"
     if not dataset_path.is_file():
@@ -27,7 +160,8 @@ def evaluate_model(
 
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    df = pd.read_csv(dataset_path)
+    full_df = pd.read_csv(dataset_path)
+    df = _select_eval_rows(full_df, dataset_dir, split)
     y = df["label_code"].astype(str)
 
     bundle = load_model_bundle(model_dir)
@@ -50,10 +184,19 @@ def evaluate_model(
     reg_carbon = bundle["regressors"]["carbon"]
     reg_energy = bundle["regressors"]["energy"]
 
-    y_pred = clf.predict(X)
-    fit_pred = reg_fit.predict(X)
-    carbon_pred = reg_carbon.predict(X)
-    energy_pred = reg_energy.predict(X)
+    if len(df):
+        y_pred = clf.predict(X)
+        fit_pred = reg_fit.predict(X)
+        carbon_pred = reg_carbon.predict(X)
+        energy_pred = reg_energy.predict(X)
+        probs = clf.predict_proba(X)
+        confidences = [float(row.max()) for row in probs]
+    else:
+        y_pred = []
+        fit_pred = []
+        carbon_pred = []
+        energy_pred = []
+        confidences = []
 
     resolved = resolve_thresholds(
         bundle.get("thresholds", {}),
@@ -64,9 +207,6 @@ def evaluate_model(
     confidence_min = float(resolved["confidence_min"])
     ood_method = str(resolved["ood_method"])
     ood_max = float(resolved["ood_threshold"])
-
-    probs = clf.predict_proba(X)
-    confidences = [float(row.max()) for row in probs]
 
     ood_count = 0
     low_conf_count = 0
@@ -87,6 +227,7 @@ def evaluate_model(
         "summary": {
             "rows": int(len(df)),
             "policy": str(resolved["ml_policy"]),
+            "split": str(split),
             "fallback_rate": float((ood_count + low_conf_count) / max(len(df), 1)),
             "ood_rate": float(ood_count / max(len(df), 1)),
             "ood_method": ood_method,
@@ -109,6 +250,47 @@ def evaluate_model(
         },
     }
 
+    df_metrics = df.copy()
+    df_metrics["fit_pred"] = fit_pred
+    df_metrics["carbon_pred"] = carbon_pred
+    df_metrics["energy_pred"] = energy_pred
+
+    holdout_report = {
+        "overall": {
+            key: _calc_target_metrics(df_metrics, key, f"{pred}_pred") for key, pred in TARGET_TO_PRED.items()
+        },
+        "worst_bin_error": _worst_bin_metrics(df_metrics, target="fit_true", pred_col="fit_pred"),
+        "bias": {
+            key: {
+                "mean_error": vals["mean_error"],
+                "mean_percentage_error_pct": vals["mean_percentage_error_pct"],
+            }
+            for key, vals in {
+                k: _calc_target_metrics(df_metrics, k, f"{p}_pred") for k, p in TARGET_TO_PRED.items()
+            }.items()
+        },
+    }
+    evaluation["holdout_report"] = holdout_report
+
+    threshold_status = None
+    if signoff_thresholds is not None:
+        thresholds_payload = json.loads(signoff_thresholds.read_text(encoding="utf-8"))
+        threshold_status = _evaluate_thresholds(holdout_report, thresholds_payload)
+        evaluation["signoff"] = {
+            "thresholds_file": str(signoff_thresholds),
+            **threshold_status,
+        }
+        if strict_signoff and not bool(threshold_status["pass"]):
+            raise ValueError("Signoff thresholds failed in strict mode")
+
     out = out_dir / "evaluation.json"
     out.write_text(json.dumps(evaluation, indent=2), encoding="utf-8")
-    return {"evaluation": out}
+
+    holdout_out = out_dir / "holdout_report.json"
+    holdout_out.write_text(json.dumps(holdout_report, indent=2), encoding="utf-8")
+    artifacts = {"evaluation": out, "holdout_report": holdout_out}
+    if threshold_status is not None:
+        signoff_out = out_dir / "signoff_status.json"
+        signoff_out.write_text(json.dumps(threshold_status, indent=2), encoding="utf-8")
+        artifacts["signoff"] = signoff_out
+    return artifacts

--- a/ml/splits.py
+++ b/ml/splits.py
@@ -1,0 +1,101 @@
+"""Deterministic dataset splitting utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def _score_for_group(group_key: str, seed: int) -> float:
+    payload = f"{seed}:{group_key}".encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    raw = int(digest[:16], 16)
+    return raw / float(0xFFFFFFFFFFFFFFFF)
+
+
+def create_deterministic_splits(
+    dataset_dir: Path,
+    out_path: Path | None = None,
+    *,
+    seed: int = 1,
+    train_ratio: float = 0.7,
+    validation_ratio: float = 0.15,
+    holdout_ratio: float = 0.15,
+    group_column: str = "scenario_hash",
+) -> Path:
+    """Create deterministic train/validation/holdout splits for dataset.csv."""
+
+    if abs((train_ratio + validation_ratio + holdout_ratio) - 1.0) > 1e-9:
+        raise ValueError("Split ratios must sum to 1.0")
+
+    dataset_path = dataset_dir / "dataset.csv"
+    if not dataset_path.is_file():
+        raise FileNotFoundError(f"Missing dataset file: {dataset_path}")
+
+    df = pd.read_csv(dataset_path)
+    if group_column not in df.columns:
+        raise ValueError(f"Missing group column in dataset: {group_column}")
+
+    if out_path is None:
+        out_path = dataset_dir / "dataset_splits.json"
+
+    unique_groups = sorted({str(v) for v in df[group_column].astype(str)})
+    split_by_group: dict[str, str] = {}
+    train_cutoff = float(train_ratio)
+    validation_cutoff = float(train_ratio + validation_ratio)
+
+    for group_key in unique_groups:
+        score = _score_for_group(group_key, seed)
+        if score < train_cutoff:
+            split_by_group[group_key] = "train"
+        elif score < validation_cutoff:
+            split_by_group[group_key] = "validation"
+        else:
+            split_by_group[group_key] = "holdout"
+
+    # Ensure all buckets receive at least one group when feasible.
+    if len(unique_groups) >= 3:
+        for bucket in ("train", "validation", "holdout"):
+            if bucket not in split_by_group.values():
+                donor = next((b for b in ("train", "validation", "holdout") if list(split_by_group.values()).count(b) > 1), None)
+                if donor is not None:
+                    donor_groups = sorted([g for g, b in split_by_group.items() if b == donor])
+                    split_by_group[donor_groups[0]] = bucket
+
+    split_rows: dict[str, list[int]] = {"train": [], "validation": [], "holdout": []}
+    for idx, row in df.iterrows():
+        group_key = str(row[group_column])
+        split_rows[split_by_group[group_key]].append(int(idx))
+
+    payload = {
+        "dataset": str(dataset_path),
+        "seed": int(seed),
+        "group_column": str(group_column),
+        "ratios": {
+            "train": float(train_ratio),
+            "validation": float(validation_ratio),
+            "holdout": float(holdout_ratio),
+        },
+        "groups": {name: sorted(keys) for name, keys in {
+            "train": [g for g, s in split_by_group.items() if s == "train"],
+            "validation": [g for g, s in split_by_group.items() if s == "validation"],
+            "holdout": [g for g, s in split_by_group.items() if s == "holdout"],
+        }.items()},
+        "rows": {name: sorted(indices) for name, indices in split_rows.items()},
+        "counts": {
+            "train": int(len(split_rows["train"])),
+            "validation": int(len(split_rows["validation"])),
+            "holdout": int(len(split_rows["holdout"])),
+            "total": int(len(df)),
+        },
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return out_path
+
+
+__all__ = ["create_deterministic_splits"]

--- a/tests/python/test_ml_holdout_signoff.py
+++ b/tests/python/test_ml_holdout_signoff.py
@@ -1,0 +1,94 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ml.dataset import build_dataset
+from ml.evaluate import evaluate_model
+from ml.train import train_models
+from ml.splits import create_deterministic_splits
+
+from tests.python.test_ml_integration import REPO, _new_base
+
+
+def test_deterministic_split_script_reproducible():
+    base = _new_base("split_repro")
+    dataset_dir = base / "dataset"
+    split_a = base / "split_a.json"
+    split_b = base / "split_b.json"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=12)
+    create_deterministic_splits(dataset_dir, split_a, seed=99)
+    create_deterministic_splits(dataset_dir, split_b, seed=99)
+
+    assert json.loads(split_a.read_text(encoding="utf-8")) == json.loads(split_b.read_text(encoding="utf-8"))
+
+
+def test_holdout_evaluation_outputs_and_signoff_passes():
+    base = _new_base("holdout_eval")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+    eval_dir = base / "eval"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=8)
+    create_deterministic_splits(dataset_dir, seed=8)
+    train_models(dataset_dir, model_dir, seed=8, model_type="linear")
+
+    artifacts = evaluate_model(
+        dataset_dir,
+        model_dir,
+        eval_dir,
+        split="holdout",
+        signoff_thresholds=REPO / "config" / "signoff_thresholds.json",
+        strict_signoff=True,
+    )
+
+    evaluation = json.loads(artifacts["evaluation"].read_text(encoding="utf-8"))
+    holdout_report = json.loads(artifacts["holdout_report"].read_text(encoding="utf-8"))
+
+    assert evaluation["summary"]["split"] == "holdout"
+    assert evaluation["signoff"]["pass"] is True
+    assert set(holdout_report.keys()) == {"overall", "worst_bin_error", "bias"}
+    assert set(holdout_report["worst_bin_error"].keys()) == {"node", "vdd", "temp", "gate"}
+
+
+def test_holdout_strict_signoff_fails_when_thresholds_too_low(tmp_path: Path):
+    base = _new_base("holdout_fail")
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=13)
+    create_deterministic_splits(dataset_dir, seed=13)
+    train_models(dataset_dir, model_dir, seed=13, model_type="linear")
+
+    thresholds = {
+        "overall": {
+            "fit_true": {"mae": -1.0, "mape_pct": -1.0, "rmse": -1.0},
+            "carbon_true": {"mae": -1.0, "mape_pct": -1.0, "rmse": -1.0},
+            "energy_true": {"mae": -1.0, "mape_pct": -1.0, "rmse": -1.0},
+        },
+        "worst_bin": {"max_fit_mae": -1.0},
+        "bias": {"max_abs_mean_error": -1.0},
+    }
+    cfg = tmp_path / "strict_fail_thresholds.json"
+    cfg.write_text(json.dumps(thresholds, indent=2), encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        str(REPO / "eccsim.py"),
+        "ml",
+        "evaluate",
+        "--dataset",
+        str(dataset_dir),
+        "--model",
+        str(model_dir),
+        "--out",
+        str(base / "eval"),
+        "--split",
+        "holdout",
+        "--signoff-thresholds",
+        str(cfg),
+        "--strict-signoff",
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO)
+    assert res.returncode != 0


### PR DESCRIPTION
### Motivation
- Provide a reproducible train/validation/holdout splitting utility for ML datasets so holdout evaluations are deterministic.
- Compute and surface holdout evaluation metrics (MAE/MAPE/RMSE overall, worst-bin error across node/VDD/temp/gate, and bias metrics) required for signoff.
- Allow automated signoff checks against explicit thresholds and fail CI in a gated strict mode when limits are exceeded.

### Description
- Add `ml/splits.py` implementing `create_deterministic_splits(...)` that writes `dataset_splits.json` grouping by `scenario_hash` and honoring a seed and configurable ratios.
- Extend the CLI in `eccsim.py` with a new `ml split-dataset` command and extend `ml evaluate` to accept `--split`, `--signoff-thresholds`, and `--strict-signoff` flags while preserving default behavior.
- Enhance `ml/evaluate.py` to support split-aware evaluation and produce additive artifacts `holdout_report.json` (overall MAE/MAPE/RMSE, worst-bin errors, bias) and optional `signoff_status.json`; `--strict-signoff` raises an error when checks fail.
- Add `config/signoff_thresholds.json` with explicit pass/fail limits and a test suite `tests/python/test_ml_holdout_signoff.py` covering split reproducibility, holdout report contents, signoff pass, and strict-fail behavior.

### Testing
- Ran `python3 -m pytest -q tests/python/test_ml_holdout_signoff.py tests/python/test_ml_integration.py::test_ml_evaluate_smoke` and the targeted ML holdout/integration tests passed.
- Ran `make` successfully to build native components and smoke tests completed.
- Ran `make test` and `python3 -m pytest -q` (full suite); these runs exposed pre-existing lifecycle/drift/report-card expectations in unrelated tests and the full-suite runs failed due to those unrelated assertions (the new code and targeted ML tests remain passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3dc36abc832e9c39d482e9ee9203)