### PR TITLE
Add release signoff package assembly, checklist, CI gate, and tests

### DIFF
--- a/.github/workflows/signoff-gate.yml
+++ b/.github/workflows/signoff-gate.yml
@@ -1,0 +1,27 @@
+name: release-signoff-gate
+
+on:
+  release:
+    types: [published, prereleased]
+  workflow_dispatch:
+
+jobs:
+  signoff-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build and validate signoff package
+        run: |
+          VERSION="$(cat VERSION)"
+          python3 scripts/build_signoff_package.py \
+            --version "$VERSION" \
+            --holdout-metrics "reports/signoff_inputs/holdout_metrics.json" \
+            --drift-status "reports/signoff_inputs/drift_status.json" \
+            --compatibility-test-results "reports/signoff_inputs/compatibility_test_results.json"

--- a/docs/SIGNOFF_CHECKLIST.md
+++ b/docs/SIGNOFF_CHECKLIST.md
@@ -1,0 +1,41 @@
+# Release Signoff Checklist
+
+The release signoff package must be built under:
+
+- `reports/signoff/<version>/`
+
+Use `scripts/build_signoff_package.py` to assemble and validate the package.
+
+## Mandatory artifacts
+
+1. `calibration_envelope.md`
+   - Defines the calibrated validity region (node, VDD, temperature, process corner).
+2. `provenance_manifest.json`
+   - Captures data lineage and source traceability.
+3. `uncertainty_report.json`
+   - Documents uncertainty bounds used for risk-aware interpretation.
+4. `holdout_metrics.json`
+   - Contains holdout evaluation metrics and threshold pass/fail status.
+5. `drift_status.json`
+   - Reports drift severity or drift-policy action for current data.
+6. `compatibility_test_results.json`
+   - Summarizes backward-compatibility test outcomes.
+7. `summary.md`
+   - One-page executive summary in plain language for reviewers.
+
+## Release gate expectations
+
+A release is blocked when any of the following is true:
+
+- A mandatory artifact is missing.
+- Holdout metrics thresholds fail (`signoff.pass` or `thresholds_pass` is false).
+- Drift status indicates a fail condition (policy `action == "fail"` or severity `high`).
+- Compatibility results indicate failure (`pass == false` or `failed > 0`).
+
+## CI usage
+
+The GitHub release workflow runs:
+
+- `scripts/build_signoff_package.py`
+
+The command exits non-zero on any missing artifact or failed threshold, which blocks the release.

--- a/reports/signoff_inputs/README.md
+++ b/reports/signoff_inputs/README.md
@@ -1,0 +1,12 @@
+# Signoff Input Artifacts
+
+This directory is the default input location for the release signoff gate workflow.
+
+Expected files:
+
+- `holdout_metrics.json`
+- `drift_status.json`
+- `compatibility_test_results.json`
+
+These files are consumed by `scripts/build_signoff_package.py` and copied into
+`reports/signoff/<version>/` during release gating.

--- a/scripts/build_signoff_package.py
+++ b/scripts/build_signoff_package.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Assemble and validate release signoff artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+MANDATORY_ARTIFACTS = {
+    "calibration_envelope": "calibration_envelope.md",
+    "provenance_manifest": "provenance_manifest.json",
+    "uncertainty_report": "uncertainty_report.json",
+    "holdout_metrics": "holdout_metrics.json",
+    "drift_status": "drift_status.json",
+    "compatibility_test_results": "compatibility_test_results.json",
+}
+SUMMARY_FILENAME = "summary.md"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_holdout_metrics(path: Path) -> tuple[bool, str]:
+    payload = _read_json(path)
+    signoff = payload.get("signoff")
+    if isinstance(signoff, dict) and "pass" in signoff:
+        passed = bool(signoff["pass"])
+        return passed, "signoff.pass must be true"
+
+    if "thresholds_pass" in payload:
+        passed = bool(payload["thresholds_pass"])
+        return passed, "thresholds_pass must be true"
+
+    return False, "missing `signoff.pass` or `thresholds_pass`"
+
+
+def _validate_drift_status(path: Path) -> tuple[bool, str]:
+    payload = _read_json(path)
+
+    actions = payload.get("actions")
+    if isinstance(actions, dict) and "action" in actions:
+        action = str(actions["action"])
+        return action != "fail", "drift policy action must not be `fail`"
+
+    status = payload.get("status", {})
+    if isinstance(status, dict):
+        severity = str(status.get("severity", "none"))
+        drift_detected = bool(status.get("drift_detected", False))
+        if severity == "high":
+            return False, "drift severity must not be `high`"
+        if drift_detected and severity not in {"none", "low", "medium"}:
+            return False, "drift status severity is invalid"
+        return True, "drift status severity must not be `high`"
+
+    return False, "missing drift status fields"
+
+
+def _validate_compatibility_results(path: Path) -> tuple[bool, str]:
+    payload = _read_json(path)
+    if "pass" in payload:
+        return bool(payload["pass"]), "compatibility `pass` must be true"
+    if "failed" in payload:
+        return int(payload["failed"]) == 0, "compatibility `failed` must be 0"
+    return False, "missing `pass` or `failed` compatibility fields"
+
+
+def _write_summary(out_path: Path, *, version: str, statuses: list[dict[str, Any]]) -> None:
+    lines = [
+        "# Executive Summary",
+        "",
+        f"Release candidate `{version}` includes all required signoff artifacts for reviewer signoff.",
+        "",
+        "## Plain-language interpretation",
+        "",
+        "- **Calibration envelope:** Confirms where the model is valid (node, voltage, temperature, and corner limits).",
+        "- **Provenance manifest:** Records exactly where calibration data came from, so reviewers can trace inputs.",
+        "- **Uncertainty report:** Quantifies model uncertainty so decisions are not based on false precision.",
+        "- **Holdout metrics:** Shows the model still meets numerical quality thresholds on unseen data.",
+        "- **Drift status:** Checks whether new data has shifted enough to reduce trust in predictions.",
+        "- **Compatibility results:** Confirms legacy/contract tests still pass, preserving backward compatibility.",
+        "",
+        "## Gate results",
+        "",
+    ]
+    for status in statuses:
+        mark = "✅" if status["pass"] else "❌"
+        lines.append(f"- {mark} `{status['artifact']}`: {status['message']}")
+
+    failing = [s for s in statuses if not s["pass"]]
+    lines += [
+        "",
+        "## Release readiness",
+        "",
+        "- **Result:** " + ("PASS" if not failing else "FAIL"),
+        "- **Reasoning:** "
+        + (
+            "All mandatory artifacts are present and quality gates passed; outputs make literal sense for reviewer signoff."
+            if not failing
+            else "At least one mandatory artifact is missing or failed a threshold gate; release is blocked until corrected."
+        ),
+        "",
+    ]
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _default_version(repo_root: Path) -> str:
+    version_file = repo_root / "VERSION"
+    if version_file.is_file():
+        return version_file.read_text(encoding="utf-8").strip()
+    return "unversioned"
+
+
+def build_signoff_package(args: argparse.Namespace) -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    version = args.version or _default_version(repo_root)
+    out_root = Path(args.out_root)
+    out_dir = (out_root / version).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sources = {
+        "calibration_envelope": Path(args.calibration_envelope),
+        "provenance_manifest": Path(args.provenance_manifest),
+        "uncertainty_report": Path(args.uncertainty_report),
+        "holdout_metrics": Path(args.holdout_metrics),
+        "drift_status": Path(args.drift_status),
+        "compatibility_test_results": Path(args.compatibility_test_results),
+    }
+
+    for name, src in sources.items():
+        if not src.is_file():
+            raise FileNotFoundError(f"Missing mandatory signoff artifact `{name}`: {src}")
+        shutil.copy2(src, out_dir / MANDATORY_ARTIFACTS[name])
+
+    holdout_pass, holdout_msg = _validate_holdout_metrics(out_dir / MANDATORY_ARTIFACTS["holdout_metrics"])
+    drift_pass, drift_msg = _validate_drift_status(out_dir / MANDATORY_ARTIFACTS["drift_status"])
+    compat_pass, compat_msg = _validate_compatibility_results(
+        out_dir / MANDATORY_ARTIFACTS["compatibility_test_results"]
+    )
+
+    statuses = [
+        {
+            "artifact": MANDATORY_ARTIFACTS["holdout_metrics"],
+            "pass": holdout_pass,
+            "message": holdout_msg,
+        },
+        {
+            "artifact": MANDATORY_ARTIFACTS["drift_status"],
+            "pass": drift_pass,
+            "message": drift_msg,
+        },
+        {
+            "artifact": MANDATORY_ARTIFACTS["compatibility_test_results"],
+            "pass": compat_pass,
+            "message": compat_msg,
+        },
+    ]
+
+    manifest = {
+        "version": version,
+        "artifacts": {k: v for k, v in MANDATORY_ARTIFACTS.items()},
+        "status": statuses,
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    _write_summary(out_dir / SUMMARY_FILENAME, version=version, statuses=statuses)
+
+    failing = [s for s in statuses if not s["pass"]]
+    if failing:
+        raise RuntimeError(
+            "Signoff package failed gates: " + ", ".join(f"{item['artifact']} ({item['message']})" for item in failing)
+        )
+
+    print(str(out_dir))
+    return 0
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", default=None, help="Signoff package version (defaults to VERSION file).")
+    parser.add_argument(
+        "--out-root",
+        default=str(repo_root / "reports" / "signoff"),
+        help="Output root directory for signoff package versions.",
+    )
+    parser.add_argument(
+        "--calibration-envelope",
+        default=str(repo_root / "docs" / "calibration_signoff_envelope.md"),
+        help="Path to calibration envelope artifact.",
+    )
+    parser.add_argument(
+        "--provenance-manifest",
+        default=str(repo_root / "reports" / "calibration" / "provenance_manifest.json"),
+        help="Path to provenance manifest artifact.",
+    )
+    parser.add_argument(
+        "--uncertainty-report",
+        default=str(repo_root / "tech_calib_uncertainty.json"),
+        help="Path to uncertainty report artifact.",
+    )
+    parser.add_argument("--holdout-metrics", required=True, help="Path to holdout metrics JSON artifact.")
+    parser.add_argument("--drift-status", required=True, help="Path to drift status JSON artifact.")
+    parser.add_argument(
+        "--compatibility-test-results",
+        required=True,
+        help="Path to compatibility test results JSON artifact.",
+    )
+    args = parser.parse_args()
+    return build_signoff_package(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_signoff_package_builder.py
+++ b/tests/python/test_signoff_package_builder.py
@@ -1,0 +1,105 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "build_signoff_package.py"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def test_build_signoff_package_success(tmp_path: Path):
+    envelope = tmp_path / "envelope.md"
+    envelope.write_text("# envelope\n", encoding="utf-8")
+
+    provenance = tmp_path / "provenance.json"
+    _write_json(provenance, {"sources": ["fixture"]})
+
+    uncertainty = tmp_path / "uncertainty.json"
+    _write_json(uncertainty, {"bands": [0.1, 0.2]})
+
+    holdout = tmp_path / "holdout.json"
+    _write_json(holdout, {"signoff": {"pass": True}})
+
+    drift = tmp_path / "drift.json"
+    _write_json(drift, {"status": {"drift_detected": False, "severity": "none"}})
+
+    compat = tmp_path / "compat.json"
+    _write_json(compat, {"pass": True, "failed": 0})
+
+    version = "test-signoff-pass"
+    out_root = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--version",
+        version,
+        "--out-root",
+        str(out_root),
+        "--calibration-envelope",
+        str(envelope),
+        "--provenance-manifest",
+        str(provenance),
+        "--uncertainty-report",
+        str(uncertainty),
+        "--holdout-metrics",
+        str(holdout),
+        "--drift-status",
+        str(drift),
+        "--compatibility-test-results",
+        str(compat),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO)
+    assert res.returncode == 0, res.stderr
+
+    out_dir = out_root / version
+    assert (out_dir / "summary.md").is_file()
+    assert (out_dir / "manifest.json").is_file()
+
+
+def test_build_signoff_package_fails_threshold_gate(tmp_path: Path):
+    envelope = tmp_path / "envelope.md"
+    envelope.write_text("# envelope\n", encoding="utf-8")
+
+    provenance = tmp_path / "provenance.json"
+    _write_json(provenance, {"sources": ["fixture"]})
+
+    uncertainty = tmp_path / "uncertainty.json"
+    _write_json(uncertainty, {"bands": [0.1, 0.2]})
+
+    holdout = tmp_path / "holdout.json"
+    _write_json(holdout, {"signoff": {"pass": False}})
+
+    drift = tmp_path / "drift.json"
+    _write_json(drift, {"status": {"drift_detected": False, "severity": "none"}})
+
+    compat = tmp_path / "compat.json"
+    _write_json(compat, {"pass": True, "failed": 0})
+
+    out_root = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--version",
+        "test-signoff-fail",
+        "--out-root",
+        str(out_root),
+        "--calibration-envelope",
+        str(envelope),
+        "--provenance-manifest",
+        str(provenance),
+        "--uncertainty-report",
+        str(uncertainty),
+        "--holdout-metrics",
+        str(holdout),
+        "--drift-status",
+        str(drift),
+        "--compatibility-test-results",
+        str(compat),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO)
+    assert res.returncode != 0


### PR DESCRIPTION
### Motivation

- Ensure releases carry a complete, machine-validated signoff bundle of artifacts and block publishing when required artifacts are missing or quality gates fail.
- Provide a one-page plain-language executive summary so reviewers can quickly verify that outputs “make literal sense.”

### Description

- Add `docs/SIGNOFF_CHECKLIST.md` listing mandatory artifacts and release-blocking conditions and pointing to the package builder.
- Add `scripts/build_signoff_package.py` which copies required artifacts into `reports/signoff/<version>/`, validates holdout/drift/compatibility gates, emits `manifest.json`, and writes a plain-language `summary.md`; the script exposes CLI args including `--out-root` and accepts explicit artifact paths.
- Add a GitHub Actions workflow `.github/workflows/signoff-gate.yml` that runs the builder on release events and fails the release when inputs are missing or gates fail.
- Add `reports/signoff_inputs/README.md` describing the expected input files used by the release gate and add `tests/python/test_signoff_package_builder.py` with success and threshold-failure cases for the builder.

### Testing

- Ran `make` successfully to build C++ tools and smoke tests.
- Ran `make test` which executes the smoke tests and Python test suite and completed successfully.
- Ran `python3 -m pytest -q` and the full test suite passed (184 tests passed, 3 warnings), including the new `test_signoff_package_builder.py` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac4704fbe4832ea9779be078bd14cb)