### PR TITLE
Integrate SRAM ECC workflows into eccsim and selector

### DIFF
--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -94,6 +94,64 @@ _CODE_DB: Dict[str, _CodeInfo] = {
 }
 
 
+def _parity_bits_secded(word_bits: int) -> int:
+    p = 1
+    while (2**p) < (word_bits + p + 1):
+        p += 1
+    return p + 1
+
+
+def _parity_bits_taec(word_bits: int) -> int:
+    patterns = 1 + word_bits + max(0, word_bits - 1) + max(0, word_bits - 2)
+    p = 1
+    while (2**p) < patterns:
+        p += 1
+    return p
+
+
+def _parity_bits_bch(word_bits: int) -> int:
+    patterns = 1 + word_bits + (word_bits * max(0, word_bits - 1) // 2)
+    p = 1
+    while (2**p) < patterns:
+        p += 1
+    return p
+
+
+for _wb in (8, 16, 32):
+    _CODE_DB[f"sram-secded-{_wb}"] = _CodeInfo(
+        "SEC-DED",
+        parity_bits=_parity_bits_secded(_wb),
+        latency_ns=0.85 + 0.02 * (_wb / 8),
+        area_logic_mm2=0.45 + 0.05 * (_wb / 8),
+        word_bits=_wb,
+        notes=f"SRAM SEC-DED ({_wb}-bit word)",
+    )
+    _CODE_DB[f"sram-taec-{_wb}"] = _CodeInfo(
+        "TAEC",
+        parity_bits=_parity_bits_taec(_wb),
+        latency_ns=1.1 + 0.05 * (_wb / 8),
+        area_logic_mm2=0.60 + 0.08 * (_wb / 8),
+        word_bits=_wb,
+        notes=f"SRAM TAEC ({_wb}-bit word)",
+    )
+    _CODE_DB[f"sram-bch-{_wb}"] = _CodeInfo(
+        "BCH",
+        parity_bits=_parity_bits_bch(_wb),
+        latency_ns=1.4 + 0.08 * (_wb / 8),
+        area_logic_mm2=0.85 + 0.11 * (_wb / 8),
+        word_bits=_wb,
+        notes=f"SRAM BCH ({_wb}-bit word)",
+    )
+    _CODE_DB[f"sram-polar-{_wb}"] = _CodeInfo(
+        "POLAR",
+        parity_bits=max(1, _wb // 2),
+        latency_ns=1.35 + 0.07 * (_wb / 8),
+        area_logic_mm2=0.78 + 0.10 * (_wb / 8),
+        word_bits=_wb,
+        notes=f"SRAM Polar ({_wb}-bit word)",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pareto helpers
 
@@ -1143,5 +1201,4 @@ __all__ = ["select", "_pareto_front", "_nsga2_sort"]
 
 if __name__ == "__main__":
     main()
-
 

--- a/eccsim.py
+++ b/eccsim.py
@@ -38,6 +38,7 @@ from fit import (
 from energy_model import UncertaintyValidationError, energy_report
 from validation.output_sanity import OutputSanityError
 from ecc_selector import select
+from sram_workflow import run_sram_backend, run_sram_selection, write_sram_records_csv
 
 
 def _format_reliability_report(result: dict) -> str:
@@ -416,6 +417,56 @@ def main() -> None:
     report_parser.add_argument("--tempC", type=float, required=True)
     report_parser.add_argument("--json", action="store_true")
 
+    sram_parser = sub.add_parser("sram", help="SRAM-oriented ECC workflows")
+    sram_sub = sram_parser.add_subparsers(dest="sram_command")
+
+    sram_sim = sram_sub.add_parser("simulate", help="Run SRAM ECC simulation")
+    sram_sim.add_argument("--size-kb", type=int, required=True, choices=[64, 128, 256])
+    sram_sim.add_argument("--word-bits", type=int, required=True, choices=[8, 16, 32])
+    sram_sim.add_argument("--scheme", type=str, required=True, choices=["sec-ded", "taec", "bch", "polar"])
+    sram_sim.add_argument("--iterations", type=int, default=5000)
+    sram_sim.add_argument("--seed", type=int, default=42)
+    sram_sim.add_argument("--fault-model", type=str, default="adjacent")
+    sram_sim.add_argument("--json", action="store_true")
+    sram_sim.add_argument("--out-csv", type=Path, default=None)
+
+    sram_stress = sram_sub.add_parser("stress", help="Run SRAM stress campaign")
+    sram_stress.add_argument("--size-kb", type=int, required=True, choices=[64, 128, 256])
+    sram_stress.add_argument("--word-bits", type=int, required=True, choices=[8, 16, 32])
+    sram_stress.add_argument("--scheme", type=str, required=True, choices=["sec-ded", "taec", "bch", "polar"])
+    sram_stress.add_argument("--iterations", type=int, default=20000)
+    sram_stress.add_argument("--seed", type=int, default=42)
+    sram_stress.add_argument("--fault-model", type=str, default="geoburst")
+    sram_stress.add_argument("--json", action="store_true")
+    sram_stress.add_argument("--out-csv", type=Path, default=None)
+
+    sram_cmp = sram_sub.add_parser("compare", help="Compare SRAM ECC schemes")
+    sram_cmp.add_argument("--size-kb", type=int, required=True, choices=[64, 128, 256])
+    sram_cmp.add_argument("--word-bits", type=int, required=True, choices=[8, 16, 32])
+    sram_cmp.add_argument("--schemes", type=str, default="sec-ded,taec,bch,polar")
+    sram_cmp.add_argument("--iterations", type=int, default=10000)
+    sram_cmp.add_argument("--seed", type=int, default=42)
+    sram_cmp.add_argument("--fault-model", type=str, default="adjacent")
+    sram_cmp.add_argument("--json", action="store_true")
+    sram_cmp.add_argument("--out-csv", type=Path, default=None)
+
+    sram_sel = sram_sub.add_parser("select", help="SRAM-aware deterministic ECC selection")
+    sram_sel.add_argument("--size-kb", type=int, required=True, choices=[64, 128, 256])
+    sram_sel.add_argument("--word-bits", type=int, required=True, choices=[8, 16, 32])
+    sram_sel.add_argument("--schemes", type=str, default="sec-ded,taec,bch,polar")
+    sram_sel.add_argument("--node", type=int, required=True)
+    sram_sel.add_argument("--vdd", type=float, required=True)
+    sram_sel.add_argument("--temp", type=float, required=True)
+    sram_sel.add_argument("--ci", type=float, required=True)
+    sram_sel.add_argument("--bitcell-um2", type=float, required=True)
+    sram_sel.add_argument("--lifetime-h", type=float, default=float("nan"))
+    sram_sel.add_argument("--mbu", type=str, default="moderate")
+    sram_sel.add_argument("--scrub-s", type=float, default=10.0)
+    sram_sel.add_argument("--alt-km", type=float, default=0.0)
+    sram_sel.add_argument("--latitude", type=float, default=45.0)
+    sram_sel.add_argument("--flux-rel", type=float, default=None)
+    sram_sel.add_argument("--report", type=Path, default=None)
+    sram_sel.add_argument("--emit-candidates", type=Path, default=None)
     ml_parser = sub.add_parser("ml", help="Optional ML advisory workflows")
     ml_sub = ml_parser.add_subparsers(dest="ml_command")
 
@@ -596,6 +647,88 @@ def main() -> None:
         else:
             parser.error("ml subcommand required")
         return
+
+    if args.command == "sram":
+        repo_root = Path(__file__).resolve().parent
+        if args.sram_command in {"simulate", "stress", "compare"}:
+            if args.sram_command in {"simulate", "stress"}:
+                schemes = [args.scheme]
+            else:
+                schemes = [c.strip() for c in args.schemes.split(",") if c.strip()]
+            try:
+                result = run_sram_backend(
+                    repo_root=repo_root,
+                    mode=args.sram_command,
+                    size_kb=args.size_kb,
+                    word_bits=args.word_bits,
+                    schemes=schemes,
+                    iterations=args.iterations,
+                    seed=args.seed,
+                    fault_model=args.fault_model,
+                )
+            except Exception as exc:
+                parser.error(str(exc))
+
+            if args.out_csv:
+                write_sram_records_csv(args.out_csv, result["records"])
+
+            if args.json:
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                records = result.get("records", [])
+                print(f"backend={result['backend']} scenario_hash={result['scenario_hash']} records={len(records)}")
+                for rec in records:
+                    print(
+                        f"{rec['codec']} reliability={rec['reliability_success']:.4f} "
+                        f"sdc={rec['sdc_rate']:.3e} energy_proxy={rec['energy_proxy']:.4f} "
+                        f"latency_proxy={rec['latency_proxy']:.4f} utility={rec['utility']:.4f}"
+                    )
+            return
+
+        if args.sram_command == "select":
+            schemes = [c.strip() for c in args.schemes.split(",") if c.strip()]
+            try:
+                result = run_sram_selection(
+                    schemes=schemes,
+                    size_kb=args.size_kb,
+                    word_bits=args.word_bits,
+                    node=args.node,
+                    vdd=args.vdd,
+                    temp=args.temp,
+                    ci=args.ci,
+                    bitcell_um2=args.bitcell_um2,
+                    lifetime_h=args.lifetime_h,
+                    mbu=args.mbu,
+                    scrub_s=args.scrub_s,
+                    flux_rel=args.flux_rel,
+                    alt_km=args.alt_km,
+                    latitude_deg=args.latitude,
+                )
+            except Exception as exc:
+                parser.error(str(exc))
+
+            if args.report:
+                args.report.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+            if args.emit_candidates:
+                import csv
+
+                rows = result.get("candidate_records", [])
+                if rows:
+                    fieldnames = list(rows[0].keys())
+                else:
+                    fieldnames = ["code", "FIT", "carbon_kg", "latency_ns", "ESII", "NESII", "GS"]
+                with args.emit_candidates.open("w", newline="", encoding="utf-8") as fh:
+                    writer = csv.DictWriter(fh, fieldnames=fieldnames, extrasaction="ignore")
+                    writer.writeheader()
+                    for row in rows:
+                        writer.writerow(row)
+
+            if result.get("best"):
+                best = result["best"]
+                print(f"{best['code']} ESII={best['ESII']:.3g} NESII={best['NESII']:.2f} GS={best['GS']:.2f}")
+            return
+
+        parser.error("sram subcommand required")
 
     if args.command == "plot":
         if args.plot_command == "pareto":

--- a/sram_workflow.py
+++ b/sram_workflow.py
@@ -1,0 +1,260 @@
+"""SRAM-oriented ECC workflow adapters.
+
+This module integrates the PracticalSRAMSimulator C++ backend into the Python
+CLI/reporting stack while preserving deterministic selector semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Dict, Iterable, List, Mapping
+
+from ecc_selector import select
+
+SUPPORTED_SRAM_KB = (64, 128, 256)
+SUPPORTED_WORD_BITS = (8, 16, 32)
+SUPPORTED_SCHEMES = ("sec-ded", "taec", "bch", "polar")
+
+_SCHEME_TO_CODEC = {
+    "sec-ded": "secded",
+    "taec": "taec",
+    "bch": "bch",
+    "polar": "polar",
+}
+
+_SCHEME_TO_SELECTOR_FAMILY = {
+    "sec-ded": "secded",
+    "taec": "taec",
+    "bch": "bch",
+    "polar": "polar",
+}
+
+
+@dataclass(frozen=True)
+class SRAMScenario:
+    size_kb: int
+    word_bits: int
+    iterations: int
+    seed: int
+    fault_model: str
+
+
+def _validate(size_kb: int, word_bits: int, schemes: Iterable[str]) -> List[str]:
+    if size_kb not in SUPPORTED_SRAM_KB:
+        raise ValueError(f"size-kb must be one of {SUPPORTED_SRAM_KB}")
+    if word_bits not in SUPPORTED_WORD_BITS:
+        raise ValueError(f"word-bits must be one of {SUPPORTED_WORD_BITS}")
+    cleaned = []
+    for scheme in schemes:
+        s = scheme.strip().lower()
+        if not s:
+            continue
+        if s not in SUPPORTED_SCHEMES:
+            raise ValueError(f"Unsupported SRAM scheme '{scheme}'")
+        cleaned.append(s)
+    if not cleaned:
+        raise ValueError("At least one SRAM scheme must be provided")
+    return cleaned
+
+
+def selector_code_for_sram_scheme(scheme: str, word_bits: int) -> str:
+    return f"sram-{_SCHEME_TO_SELECTOR_FAMILY[scheme]}-{word_bits}"
+
+
+def _scenario_hash(scenario: Mapping[str, object]) -> str:
+    return hashlib.sha1(json.dumps(dict(scenario), sort_keys=True).encode()).hexdigest()
+
+
+def _map_result_row(row: Mapping[str, object], *, scenario: SRAMScenario) -> Dict[str, object]:
+    metrics = row.get("metrics", {})
+    stats = row.get("stats", {})
+    corrected = float(stats.get("corrected", 0.0))
+    detected_uncorrectable = float(stats.get("detected_uncorrectable", 0.0))
+    undetected = float(stats.get("undetected", 0.0))
+    total_reads = max(float(stats.get("reads", 0.0)), 1.0)
+    rel_success = (corrected + detected_uncorrectable) / total_reads
+
+    return {
+        "codec": row.get("codec"),
+        "size_kb": int(row.get("size_kb", scenario.size_kb)),
+        "word_bits": int(row.get("word_bits", scenario.word_bits)),
+        "fault_model": row.get("fault_model", scenario.fault_model),
+        "iterations": int(row.get("iterations", scenario.iterations)),
+        "reliability_success": rel_success,
+        "sdc_rate": float(metrics.get("sdc_pct", 0.0)) / 100.0,
+        "effective_protection": float(metrics.get("effective_protection_score", 0.0)),
+        "redundancy_overhead_pct": float(metrics.get("expansion_pct", 0.0)),
+        "energy_proxy": float(metrics.get("normalized_energy", 0.0)),
+        "latency_proxy": float(metrics.get("normalized_latency", 0.0)),
+        "utility": float(metrics.get("effective_protection_score", 0.0))
+        / (1.0 + float(metrics.get("normalized_energy", 0.0)) + float(metrics.get("normalized_latency", 0.0))),
+        "raw": row,
+    }
+
+
+def run_sram_backend(
+    *,
+    repo_root: Path,
+    mode: str,
+    size_kb: int,
+    word_bits: int,
+    schemes: Iterable[str],
+    iterations: int,
+    seed: int,
+    fault_model: str,
+) -> Dict[str, object]:
+    cleaned = _validate(size_kb, word_bits, schemes)
+    scenario = SRAMScenario(size_kb=size_kb, word_bits=word_bits, iterations=iterations, seed=seed, fault_model=fault_model)
+    exe = repo_root / "PracticalSRAMSimulator"
+
+    scenario_meta = {
+        "size_kb": size_kb,
+        "word_bits": word_bits,
+        "iterations": iterations,
+        "seed": seed,
+        "fault_model": fault_model,
+        "mode": mode,
+        "schemes": cleaned,
+    }
+
+    rows: List[Dict[str, object]] = []
+    backend = "python-fallback"
+    if exe.exists():
+        backend = "cpp-practical"
+        codec = "all" if len(cleaned) > 1 else _SCHEME_TO_CODEC[cleaned[0]]
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp:
+            export_path = Path(tmp.name)
+        cmd = [
+            str(exe),
+            "--mode",
+            "compare" if mode == "compare" else "stress",
+            "--codec",
+            codec,
+            "--size-kb",
+            str(size_kb),
+            "--word-bits",
+            str(word_bits),
+            "--iterations",
+            str(iterations),
+            "--seed",
+            str(seed),
+            "--fault-model",
+            fault_model,
+            "--export-json",
+            str(export_path),
+        ]
+        subprocess.run(cmd, check=True, cwd=repo_root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        export_path.unlink(missing_ok=True)
+
+        for row in payload.get("results", []):
+            codec_name = str(row.get("codec", "")).strip().lower().replace("-", "")
+            expected = _SCHEME_TO_CODEC[cleaned[0]].replace("-", "")
+            if len(cleaned) == 1 and codec_name != expected:
+                continue
+            rows.append(_map_result_row(row, scenario=scenario))
+    else:
+        # deterministic fallback: selector-derived proxies keep workflow usable
+        capacity_gib = size_kb / (1024 * 1024)
+        selector_codes = [selector_code_for_sram_scheme(s, word_bits) for s in cleaned]
+        sel = select(
+            selector_codes,
+            node=14,
+            vdd=0.8,
+            temp=75.0,
+            capacity_gib=capacity_gib,
+            ci=0.3,
+            bitcell_um2=0.08,
+            lifetime_h=8760.0,
+            mbu="moderate",
+            scrub_s=10.0,
+        )
+        for rec in sel.get("candidate_records", []):
+            rows.append(
+                {
+                    "codec": rec["code"],
+                    "size_kb": size_kb,
+                    "word_bits": word_bits,
+                    "fault_model": fault_model,
+                    "iterations": iterations,
+                    "reliability_success": max(0.0, 1.0 - rec.get("fit_word_post", 0.0) * 1e-9),
+                    "sdc_rate": rec.get("fit_word_post", 0.0) * 1e-12,
+                    "effective_protection": rec.get("GS", 0.0),
+                    "redundancy_overhead_pct": 100.0 * rec.get("area_macro_mm2", 0.0) / max(rec.get("area_logic_mm2", 1.0), 1e-9),
+                    "energy_proxy": rec.get("E_scrub_kWh", 0.0),
+                    "latency_proxy": rec.get("latency_ns", 0.0),
+                    "utility": rec.get("NESII", 0.0),
+                    "raw": rec,
+                }
+            )
+
+    return {
+        "backend": backend,
+        "scenario": scenario_meta,
+        "scenario_hash": _scenario_hash(scenario_meta),
+        "records": rows,
+    }
+
+
+def run_sram_selection(
+    *,
+    schemes: Iterable[str],
+    size_kb: int,
+    word_bits: int,
+    node: int,
+    vdd: float,
+    temp: float,
+    ci: float,
+    bitcell_um2: float,
+    lifetime_h: float,
+    mbu: str,
+    scrub_s: float,
+    flux_rel: float | None,
+    alt_km: float,
+    latitude_deg: float,
+) -> Dict[str, object]:
+    cleaned = _validate(size_kb, word_bits, schemes)
+    codes = [selector_code_for_sram_scheme(s, word_bits) for s in cleaned]
+    return select(
+        codes,
+        node=node,
+        vdd=vdd,
+        temp=temp,
+        capacity_gib=size_kb / (1024 * 1024),
+        ci=ci,
+        bitcell_um2=bitcell_um2,
+        lifetime_h=lifetime_h,
+        mbu=mbu,
+        scrub_s=scrub_s,
+        flux_rel=flux_rel,
+        alt_km=alt_km,
+        latitude_deg=latitude_deg,
+    )
+
+
+def write_sram_records_csv(path: Path, rows: Iterable[Mapping[str, object]]) -> None:
+    fieldnames = [
+        "codec",
+        "size_kb",
+        "word_bits",
+        "fault_model",
+        "iterations",
+        "reliability_success",
+        "sdc_rate",
+        "effective_protection",
+        "redundancy_overhead_pct",
+        "energy_proxy",
+        "latency_proxy",
+        "utility",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k) for k in fieldnames})

--- a/tests/python/test_sram_cli.py
+++ b/tests/python/test_sram_cli.py
@@ -1,0 +1,111 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "eccsim.py"
+
+
+def _run(*args: str):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO,
+    )
+
+
+def test_sram_simulate_json_contract(tmp_path: Path):
+    out_csv = tmp_path / "sram_sim.csv"
+    res = _run(
+        "sram",
+        "simulate",
+        "--size-kb",
+        "64",
+        "--word-bits",
+        "8",
+        "--scheme",
+        "sec-ded",
+        "--iterations",
+        "20",
+        "--seed",
+        "7",
+        "--json",
+        "--out-csv",
+        str(out_csv),
+    )
+    payload = json.loads(res.stdout)
+    assert "backend" in payload
+    assert "scenario_hash" in payload
+    assert payload["records"]
+    row = payload["records"][0]
+    for key in (
+        "codec",
+        "size_kb",
+        "word_bits",
+        "reliability_success",
+        "energy_proxy",
+        "latency_proxy",
+        "redundancy_overhead_pct",
+        "utility",
+    ):
+        assert key in row
+    assert out_csv.exists()
+
+
+def test_sram_compare_includes_requested_schemes_json():
+    res = _run(
+        "sram",
+        "compare",
+        "--size-kb",
+        "128",
+        "--word-bits",
+        "16",
+        "--schemes",
+        "sec-ded,taec,bch,polar",
+        "--iterations",
+        "20",
+        "--seed",
+        "9",
+        "--json",
+    )
+    payload = json.loads(res.stdout)
+    codecs = {str(r["codec"]).lower() for r in payload["records"]}
+    assert len(codecs) >= 4
+
+
+def test_sram_select_deterministic_path(tmp_path: Path):
+    report = tmp_path / "sram_select.json"
+    candidates = tmp_path / "sram_candidates.csv"
+    res = _run(
+        "sram",
+        "select",
+        "--size-kb",
+        "256",
+        "--word-bits",
+        "32",
+        "--schemes",
+        "sec-ded,taec,bch,polar",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ci",
+        "0.3",
+        "--bitcell-um2",
+        "0.08",
+        "--report",
+        str(report),
+        "--emit-candidates",
+        str(candidates),
+    )
+    assert "sram-" in res.stdout
+    assert report.exists()
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert "best" in data
+    assert candidates.exists()

--- a/tests/python/test_sram_selector_codes.py
+++ b/tests/python/test_sram_selector_codes.py
@@ -1,0 +1,20 @@
+from ecc_selector import select
+
+
+def _params():
+    return {
+        "node": 14,
+        "vdd": 0.8,
+        "temp": 75.0,
+        "capacity_gib": 64 / (1024 * 1024),
+        "ci": 0.3,
+        "bitcell_um2": 0.08,
+        "lifetime_h": 8760.0,
+    }
+
+
+def test_sram_codes_supported_in_selector():
+    codes = ["sram-secded-8", "sram-taec-8", "sram-bch-8", "sram-polar-8"]
+    result = select(codes, **_params())
+    assert result["best"] is not None
+    assert len(result["candidate_records"]) == 4


### PR DESCRIPTION
### Motivation
- Expose the PracticalSRAMSimulator SRAM research simulator as a first-class workflow in the existing CLI/selection/analysis framework rather than leaving it as a standalone tool. 
- Make SRAM-oriented ECC options (SEC‑DED, TAEC, BCH, Polar) selectable and consumable by the deterministic `ecc_selector`/analysis pipelines while preserving backward compatibility. 

### Description
- Add a new adapter module `sram_workflow.py` that prefers the compiled `PracticalSRAMSimulator` backend and provides a deterministic Python fallback mapping simulator outputs into framework-compatible proxies (`reliability_success`, `sdc_rate`, `energy_proxy`, `latency_proxy`, `redundancy_overhead_pct`, `utility`).
- Extend `eccsim.py` with a new `sram` command group and subcommands: `simulate`, `stress`, `compare`, and `select`, supporting options for `--size-kb` (64/128/256), `--word-bits` (8/16/32), schemes (`sec-ded/taec/bch/polar`), JSON/CSV emission, and selection/reporting hooks.
- Add SRAM candidate entries into the selector `_CODE_DB` (additive) for `sram-secded-*`, `sram-taec-*`, `sram-bch-*`, and `sram-polar-*` (8/16/32-bit variants) so the deterministic `select` flow can consume SRAM options without changing existing behavior.
- Add tests: `tests/python/test_sram_cli.py` validates CLI JSON/CSV contract and outputs, and `tests/python/test_sram_selector_codes.py` validates selector support for new SRAM candidate identifiers; all changes are additive and do not alter existing CLI outputs.

### Testing
- Ran `make` to build C++ binaries and `PracticalSRAMSimulator` successfully, and then `make test`; the full test suite and smoke tests executed as part of the Makefile targets and succeeded.
- Ran `python3 -m pytest -q` (full Python test suite) and targeted SRAM tests; final run produced `188 passed, 3 warnings` and the new SRAM-specific tests passed (`4 passed` for the added tests).
- Verified targeted commands: `python3 eccsim.py sram simulate ... --json`, `python3 eccsim.py sram compare ... --json`, and `python3 eccsim.py sram select ... --report ... --emit-candidates ...` during test runs and test fixtures exercised JSON/CSV outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5b0ff868832e9638b3be73627434)