### PR TITLE
Add optional advisory ML integration for SRAM selection

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -467,6 +467,14 @@ def main() -> None:
     sram_sel.add_argument("--flux-rel", type=float, default=None)
     sram_sel.add_argument("--report", type=Path, default=None)
     sram_sel.add_argument("--emit-candidates", type=Path, default=None)
+    sram_sel.add_argument("--ml-model", type=Path, default=None)
+    sram_sel.add_argument("--ml-confidence-min", type=float, default=None)
+    sram_sel.add_argument("--ml-ood-max", type=float, default=None)
+    sram_sel.add_argument(
+        "--ml-policy",
+        choices=["carbon_min", "fit_min", "energy_min", "utility_balanced"],
+        default=None,
+    )
     ml_parser = sub.add_parser("ml", help="Optional ML advisory workflows")
     ml_sub = ml_parser.add_subparsers(dest="ml_command")
 
@@ -703,6 +711,10 @@ def main() -> None:
                     flux_rel=args.flux_rel,
                     alt_km=args.alt_km,
                     latitude_deg=args.latitude,
+                    ml_model=args.ml_model,
+                    ml_confidence_min=args.ml_confidence_min,
+                    ml_ood_max=args.ml_ood_max,
+                    ml_policy=args.ml_policy,
                 )
             except Exception as exc:
                 parser.error(str(exc))

--- a/ml/sram_advisory.py
+++ b/ml/sram_advisory.py
@@ -1,0 +1,187 @@
+"""SRAM-specific advisory ML helpers.
+
+This module keeps deterministic SRAM selection as the primary decision path and
+reuses the shared ML prediction/gating utilities for optional advisory output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from ml.predict import predict_with_model, resolve_thresholds
+
+
+_ML_POLICIES = {"carbon_min", "fit_min", "energy_min", "utility_balanced"}
+
+
+def _scheme_from_code(code: str) -> str:
+    parts = str(code).split("-")
+    if len(parts) >= 3 and parts[0] == "sram":
+        return parts[1]
+    return "unknown"
+
+
+def build_sram_feature_row(
+    candidate: Mapping[str, object],
+    *,
+    size_kb: int,
+    word_bits: int,
+    fault_model: str,
+    iterations: int,
+) -> dict[str, object]:
+    """Build an SRAM-aware feature row from selector candidate/scenario fields."""
+
+    fit_val = float(candidate.get("FIT", 0.0))
+    return {
+        # Core selector-compatible features.
+        "code": str(candidate.get("code", "")),
+        "node": candidate.get("node"),
+        "vdd": candidate.get("vdd"),
+        "temp": candidate.get("temp"),
+        "capacity_gib": candidate.get("capacity_gib"),
+        "ci": candidate.get("ci"),
+        "bitcell_um2": candidate.get("bitcell_um2"),
+        "scrub_s": candidate.get("scrub_s"),
+        "latency_ns": candidate.get("latency_ns"),
+        "area_logic_mm2": candidate.get("area_logic_mm2"),
+        "area_macro_mm2": candidate.get("area_macro_mm2"),
+        # SRAM-specific advisory context.
+        "size_kb": int(size_kb),
+        "word_bits": int(word_bits),
+        "scheme": _scheme_from_code(str(candidate.get("code", ""))),
+        "fault_model": str(fault_model),
+        "iterations": int(iterations),
+        "redundancy_overhead_pct": candidate.get("redundancy_overhead_pct"),
+        "reliability_success": max(0.0, 1.0 - fit_val * 1e-9),
+        "sdc_rate": fit_val * 1e-12,
+        "correction_rate": candidate.get("correction_rate", 0.0),
+        "detection_rate": candidate.get("detection_rate", 0.0),
+        "energy_proxy": candidate.get("E_scrub_kWh"),
+        "latency_proxy": candidate.get("latency_ns"),
+        "utility": candidate.get("NESII"),
+    }
+
+
+def _pick_advisory_candidate(
+    entries: list[dict[str, object]],
+    policy: str,
+) -> dict[str, object]:
+    if not entries:
+        raise ValueError("No eligible advisory entries")
+
+    policy_norm = str(policy).strip().lower()
+    if policy_norm == "fit_min":
+        return min(entries, key=lambda e: float(e["prediction"]["predictions"].get("FIT", float("inf"))))
+    if policy_norm == "energy_min":
+        return min(entries, key=lambda e: float(e["prediction"]["predictions"].get("energy_kWh", float("inf"))))
+    if policy_norm == "utility_balanced":
+        fits = [float(e["prediction"]["predictions"].get("FIT", float("inf"))) for e in entries]
+        carbons = [float(e["prediction"]["predictions"].get("carbon_kg", float("inf"))) for e in entries]
+        energies = [float(e["prediction"]["predictions"].get("energy_kWh", float("inf"))) for e in entries]
+
+        def _norm(vals: list[float], value: float) -> float:
+            lo = min(vals)
+            hi = max(vals)
+            if hi <= lo:
+                return 0.0
+            return (value - lo) / (hi - lo)
+
+        return min(
+            entries,
+            key=lambda e: (
+                _norm(fits, float(e["prediction"]["predictions"].get("FIT", float("inf"))))
+                + _norm(carbons, float(e["prediction"]["predictions"].get("carbon_kg", float("inf"))))
+                + _norm(energies, float(e["prediction"]["predictions"].get("energy_kWh", float("inf")))),
+            ),
+        )
+
+    return min(entries, key=lambda e: float(e["prediction"]["predictions"].get("carbon_kg", float("inf"))))
+
+
+def run_sram_advisory(
+    *,
+    model_dir: Path,
+    candidates: list[dict[str, object]],
+    baseline_choice: str | None,
+    size_kb: int,
+    word_bits: int,
+    fault_model: str = "adjacent",
+    iterations: int = 1,
+    confidence_min_override: float | None = None,
+    ood_threshold_override: float | None = None,
+    policy_override: str | None = None,
+) -> dict[str, object]:
+    """Evaluate SRAM candidates with shared ML gating and return advisory metadata."""
+
+    resolved_thresholds = resolve_thresholds(
+        {},
+        model_dir=model_dir,
+        confidence_min_override=confidence_min_override,
+        ood_threshold_override=ood_threshold_override,
+        policy_override=policy_override,
+    )
+    policy = str(resolved_thresholds.get("ml_policy", "carbon_min"))
+    if policy not in _ML_POLICIES:
+        policy = "carbon_min"
+
+    eligible: list[dict[str, object]] = []
+    rejected: list[dict[str, object]] = []
+
+    for rec in candidates:
+        row = build_sram_feature_row(
+            rec,
+            size_kb=size_kb,
+            word_bits=word_bits,
+            fault_model=fault_model,
+            iterations=iterations,
+        )
+        pred = predict_with_model(
+            model_dir,
+            row,
+            confidence_min_override=confidence_min_override,
+            ood_threshold_override=ood_threshold_override,
+            policy_override=policy_override,
+        )
+        diag = {
+            "code": rec.get("code"),
+            "confidence": float(pred.get("confidence", 0.0)),
+            "ood_score": float(pred.get("ood_score", 0.0)),
+        }
+        if bool(pred.get("ood", False)) or bool(pred.get("low_confidence", False)):
+            rejected.append(diag)
+        else:
+            eligible.append({"record": rec, "prediction": pred, "diag": diag})
+
+    advisory_choice = None
+    advisory_prediction = None
+    if eligible:
+        picked = _pick_advisory_candidate(eligible, policy)
+        advisory_choice = str(picked["record"].get("code"))
+        advisory_prediction = picked["prediction"]
+
+    fallback_used = advisory_prediction is None
+    final_choice_reason = "deterministic_baseline_primary"
+    if fallback_used:
+        final_choice_reason = "ml_rejected_fallback_to_deterministic_baseline"
+    elif advisory_choice != baseline_choice:
+        final_choice_reason = "deterministic_baseline_primary_ml_advisory_only"
+
+    return {
+        "ml_requested": True,
+        "ml_used": advisory_prediction is not None,
+        "fallback_used": fallback_used,
+        "baseline_choice": baseline_choice,
+        "advisory_choice": advisory_choice,
+        "advisory_confidence": (
+            float(advisory_prediction.get("confidence", 0.0)) if advisory_prediction else None
+        ),
+        "advisory_ood_score": (
+            float(advisory_prediction.get("ood_score", 0.0)) if advisory_prediction else None
+        ),
+        "advisory_policy": policy,
+        "final_choice": baseline_choice,
+        "final_choice_reason": final_choice_reason,
+        "advisory_rejected_candidates": rejected,
+    }
+

--- a/sram_workflow.py
+++ b/sram_workflow.py
@@ -218,10 +218,16 @@ def run_sram_selection(
     flux_rel: float | None,
     alt_km: float,
     latitude_deg: float,
+    ml_model: Path | None = None,
+    ml_confidence_min: float | None = None,
+    ml_ood_max: float | None = None,
+    ml_policy: str | None = None,
+    fault_model: str = "adjacent",
+    iterations: int = 1,
 ) -> Dict[str, object]:
     cleaned = _validate(size_kb, word_bits, schemes)
     codes = [selector_code_for_sram_scheme(s, word_bits) for s in cleaned]
-    return select(
+    result = select(
         codes,
         node=node,
         vdd=vdd,
@@ -236,6 +242,28 @@ def run_sram_selection(
         alt_km=alt_km,
         latitude_deg=latitude_deg,
     )
+
+    if ml_model is None:
+        return result
+
+    from ml.sram_advisory import run_sram_advisory
+
+    baseline = result.get("best") if isinstance(result.get("best"), dict) else None
+    baseline_choice = baseline.get("code") if isinstance(baseline, dict) else None
+    advisory = run_sram_advisory(
+        model_dir=Path(ml_model),
+        candidates=list(result.get("candidate_records", [])),
+        baseline_choice=baseline_choice,
+        size_kb=size_kb,
+        word_bits=word_bits,
+        fault_model=fault_model,
+        iterations=iterations,
+        confidence_min_override=ml_confidence_min,
+        ood_threshold_override=ml_ood_max,
+        policy_override=ml_policy,
+    )
+    result.update(advisory)
+    return result
 
 
 def write_sram_records_csv(path: Path, rows: Iterable[Mapping[str, object]]) -> None:

--- a/tests/python/test_sram_cli.py
+++ b/tests/python/test_sram_cli.py
@@ -1,7 +1,11 @@
 import json
 import subprocess
 import sys
+import uuid
 from pathlib import Path
+
+from ml.dataset import build_dataset
+from ml.train import train_models
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -108,4 +112,130 @@ def test_sram_select_deterministic_path(tmp_path: Path):
     assert report.exists()
     data = json.loads(report.read_text(encoding="utf-8"))
     assert "best" in data
+    assert "ml_requested" not in data
     assert candidates.exists()
+
+
+def _prepare_model(tag: str) -> Path:
+    base = REPO / "tests" / "fixtures" / "runtime_ml_tests" / f"sram_{tag}_{uuid.uuid4().hex}"
+    dataset_dir = base / "dataset"
+    model_dir = base / "model"
+    dataset_dir.parent.mkdir(parents=True, exist_ok=True)
+    build_dataset(REPO / "reports" / "examples", dataset_dir, seed=1)
+    train_models(dataset_dir, model_dir, seed=1)
+    return model_dir
+
+
+def test_sram_select_ml_advisory_fields_present(tmp_path: Path):
+    model_dir = _prepare_model("advisory")
+    report = tmp_path / "sram_select_ml.json"
+    _run(
+        "sram",
+        "select",
+        "--size-kb",
+        "256",
+        "--word-bits",
+        "32",
+        "--schemes",
+        "sec-ded,taec,bch,polar",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ci",
+        "0.3",
+        "--bitcell-um2",
+        "0.08",
+        "--ml-model",
+        str(model_dir),
+        "--report",
+        str(report),
+    )
+    data = json.loads(report.read_text(encoding="utf-8"))
+    for key in (
+        "ml_requested",
+        "ml_used",
+        "fallback_used",
+        "baseline_choice",
+        "advisory_choice",
+        "advisory_confidence",
+        "advisory_ood_score",
+        "advisory_policy",
+        "final_choice",
+        "final_choice_reason",
+    ):
+        assert key in data
+    assert data["ml_requested"] is True
+    assert data["baseline_choice"] == data["final_choice"]
+
+
+def test_sram_select_ml_fallback_on_low_confidence(tmp_path: Path):
+    model_dir = _prepare_model("low_conf")
+    report = tmp_path / "sram_select_low_conf.json"
+    _run(
+        "sram",
+        "select",
+        "--size-kb",
+        "256",
+        "--word-bits",
+        "32",
+        "--schemes",
+        "sec-ded,taec,bch,polar",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ci",
+        "0.3",
+        "--bitcell-um2",
+        "0.08",
+        "--ml-model",
+        str(model_dir),
+        "--ml-confidence-min",
+        "0.9999",
+        "--report",
+        str(report),
+    )
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["fallback_used"] is True
+    assert data["ml_used"] is False
+    assert data["final_choice"] == data["baseline_choice"]
+
+
+def test_sram_select_ml_fallback_on_ood(tmp_path: Path):
+    model_dir = _prepare_model("ood")
+    report = tmp_path / "sram_select_ood.json"
+    _run(
+        "sram",
+        "select",
+        "--size-kb",
+        "256",
+        "--word-bits",
+        "32",
+        "--schemes",
+        "sec-ded,taec,bch,polar",
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--ci",
+        "0.3",
+        "--bitcell-um2",
+        "0.08",
+        "--ml-model",
+        str(model_dir),
+        "--ml-ood-max",
+        "0.01",
+        "--report",
+        str(report),
+    )
+    data = json.loads(report.read_text(encoding="utf-8"))
+    assert data["fallback_used"] is True
+    assert data["ml_used"] is False
+    assert data["final_choice"] == data["baseline_choice"]


### PR DESCRIPTION
### Motivation

- Enable optional ML-assisted advisory ranking for SRAM ECC selection while preserving the existing deterministic-first flow and guaranteed fallback behavior.
- Reuse the repository's shared ML gating/prediction utilities rather than creating a separate SRAM-only ML stack.
- Keep changes additive and backward-compatible so existing non-ML SRAM workflows and output schemas are unchanged when ML is not requested.

### Description

- Added CLI flags to `eccsim.py sram select`: `--ml-model`, `--ml-confidence-min`, `--ml-ood-max`, and `--ml-policy`, wired through only when ML is requested.
- Introduced `ml/sram_advisory.py` which builds SRAM-specific feature rows, reuses `ml.predict.predict_with_model` and `ml.predict.resolve_thresholds` for confidence/OOD gating, and implements policy-based advisory picking; ML remains advisory-only and never overrides the deterministic baseline.
- Extended `run_sram_selection(...)` in `sram_workflow.py` to always compute the deterministic baseline first and, if `--ml-model` is supplied, call the advisory adapter and merge additive diagnostic/decision fields into the returned result.
- Added tests in `tests/python/test_sram_cli.py` to cover: unchanged deterministic behavior when ML is not used, advisory output fields when ML is requested, fallback on low confidence, and fallback on OOD; changes are additive to existing tests.

### Testing

- Ran focused tests: `python3 -m pytest -q tests/python/test_sram_cli.py tests/python/test_ml_integration.py::test_selector_ood_fallback` (passed).
- Built and ran project smoke/unit: `make` and `make test` (build and tests ran successfully).
- Ran full Python test suite: `python3 -m pytest -q` which completed successfully (tests passed; run produced a small number of benign warnings reported by sklearn).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac61e3ed24832ebe8c76f29e03c5bc)