### PR TITLE
Harden carbon calibration: provenance, validation, uncertainty separation, and selector policy tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ python3 eccsim.py carbon --areas 0.1,0.2 --alpha 120,140 --ci 0.55 --Edyn 0.01 -
 python3 eccsim.py carbon --calibrated --node 7 --area-cm2 0.02 --grid-region us --years 5 --accesses-per-day 1000000 --areas 0.1,0.2 --alpha 120,140 --ci 0.38 --Edyn 0.01 --Eleak 0.02
 
 # Selector with optional carbon policy (default remains unchanged when omitted)
-python3 eccsim.py select --codes sec-ded-64,sec-daec-64,taec-64 --node 16 --vdd 0.8 --temp 45 --mbu moderate --capacity-gib 16 --ci 0.475 --bitcell-um2 0.08 --carbon-policy minimum_total_carbon
+python3 eccsim.py select --codes sec-ded-64,sec-daec-64,taec-64 --node 16 --vdd 0.8 --temp 45 --mbu moderate --capacity-gib 16 --ci 0.301 --bitcell-um2 0.08 --carbon-policy minimum_total_carbon
 ```
 
 See `docs/carbon_calibration.md` for equations, units, assumptions, and uncertainty behavior.

--- a/carbon_calib.json
+++ b/carbon_calib.json
@@ -1,7 +1,7 @@
 {
   "node_defaults": {
     "28": {
-      "area_scaling_factor": 1.0,
+      "design_area_multiplier": 1.0,
       "fab_intensity_kgco2e_per_cm2": {
         "min": 20.0,
         "nominal": 25.0,
@@ -15,7 +15,7 @@
       "uncertainty_margin": 0.2
     },
     "16": {
-      "area_scaling_factor": 1.0,
+      "design_area_multiplier": 1.0,
       "fab_intensity_kgco2e_per_cm2": {
         "min": 40.0,
         "nominal": 50.0,
@@ -29,7 +29,7 @@
       "uncertainty_margin": 0.2
     },
     "7": {
-      "area_scaling_factor": 1.0,
+      "design_area_multiplier": 1.0,
       "fab_intensity_kgco2e_per_cm2": {
         "min": 80.0,
         "nominal": 100.0,
@@ -45,13 +45,22 @@
   },
   "grid_defaults": {
     "regions_kgco2e_per_kwh": {
-      "global_avg": 0.475,
+      "global_avg": 0.301,
       "india": 0.725,
       "us": 0.38,
       "europe": 0.295,
       "brazil": 0.082,
       "iceland": 0.028
     },
+    "region_provenance": {
+      "global_avg": "IEA electricity intensity global average proxy (kgCO2e/kWh)",
+      "india": "Regional default proxy",
+      "us": "Regional default proxy",
+      "europe": "Regional default proxy",
+      "brazil": "Regional default proxy",
+      "iceland": "Regional default proxy"
+    },
+    "scenario_provenance": "Best/worst scenario factors are stress-test envelopes and not region-average factors.",
     "best_case_kgco2e_per_kwh": 0.02,
     "worst_case_kgco2e_per_kwh": 0.9
   },

--- a/carbon_model.py
+++ b/carbon_model.py
@@ -36,15 +36,31 @@ def _as_float(value: float | int | None, name: str, *, allow_none: bool = False)
     return out
 
 
-def _resolve_node(node_nm: int, calib: Mapping[str, Any]) -> dict[str, Any]:
+def _as_positive(value: float | int | None, name: str) -> float:
+    out = float(_as_float(value, name))
+    if out <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return out
+
+
+def _resolve_node(node_nm: int, calib: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     nodes = calib["node_defaults"]
-    key = str(int(node_nm))
+    requested = int(node_nm)
+    key = str(requested)
     if key in nodes:
-        return dict(nodes[key])
+        return dict(nodes[key]), {
+            "requested_node_nm": requested,
+            "calibrated_node_nm": requested,
+            "node_mapping_mode": "exact",
+        }
     # Fallback to nearest configured node for backward-compatible operation.
     choices = sorted(int(k) for k in nodes)
-    nearest = min(choices, key=lambda n: abs(n - int(node_nm)))
-    return dict(nodes[str(nearest)])
+    nearest = min(choices, key=lambda n: abs(n - requested))
+    return dict(nodes[str(nearest)]), {
+        "requested_node_nm": requested,
+        "calibrated_node_nm": nearest,
+        "node_mapping_mode": "nearest_calibrated",
+    }
 
 
 def _resolve_area_cm2(
@@ -81,13 +97,15 @@ def estimate_embodied_carbon(
     """Estimate embodied/static carbon with nominal and bounded variants."""
 
     calib = _load_calibration(calib_path)
-    node_cfg = _resolve_node(node_nm, calib)
+    node_cfg, node_meta = _resolve_node(node_nm, calib)
     intensity_cfg = node_cfg["fab_intensity_kgco2e_per_cm2"]
     yield_cfg = node_cfg["yield_loss_factor"]
 
     scaling = float(
         _as_float(
-            area_scaling_factor if area_scaling_factor is not None else node_cfg.get("area_scaling_factor", 1.0),
+            area_scaling_factor
+            if area_scaling_factor is not None
+            else node_cfg.get("design_area_multiplier", node_cfg.get("area_scaling_factor", 1.0)),
             "area_scaling_factor",
         )
     )
@@ -97,20 +115,18 @@ def estimate_embodied_carbon(
         bitcell_area_um2=bitcell_area_um2,
         area_scaling_factor=scaling,
     )
-    resolved_yield = float(
-        _as_float(yield_loss_factor if yield_loss_factor is not None else yield_cfg["nominal"], "yield_loss_factor")
+    resolved_yield = _as_positive(
+        yield_loss_factor if yield_loss_factor is not None else yield_cfg["nominal"], "yield_loss_factor"
     )
-    resolved_intensity = float(
-        _as_float(
-            fab_intensity_kgco2e_per_cm2 if fab_intensity_kgco2e_per_cm2 is not None else intensity_cfg["nominal"],
-            "fab_intensity_kgco2e_per_cm2",
-        )
+    resolved_intensity = _as_positive(
+        fab_intensity_kgco2e_per_cm2 if fab_intensity_kgco2e_per_cm2 is not None else intensity_cfg["nominal"],
+        "fab_intensity_kgco2e_per_cm2",
     )
     margin = float(_as_float(uncertainty_margin if uncertainty_margin is not None else node_cfg["uncertainty_margin"], "uncertainty_margin"))
 
     nominal = resolved_area_cm2 * resolved_intensity * resolved_yield
-    best_case = resolved_area_cm2 * float(intensity_cfg["min"]) * float(yield_cfg["min"]) * (1.0 - margin)
-    worst_case = resolved_area_cm2 * float(intensity_cfg["max"]) * float(yield_cfg["max"]) * (1.0 + margin)
+    best_case = resolved_area_cm2 * float(intensity_cfg["min"]) * float(yield_cfg["min"])
+    worst_case = resolved_area_cm2 * float(intensity_cfg["max"]) * float(yield_cfg["max"])
 
     return {
         "nominal_kgco2e": nominal,
@@ -120,14 +136,17 @@ def estimate_embodied_carbon(
         "worst_case_kgco2e": worst_case,
         "assumptions": {
             "node_nm": int(node_nm),
+            **node_meta,
             "effective_area_cm2": resolved_area_cm2,
             "fab_intensity_kgco2e_per_cm2": resolved_intensity,
             "yield_loss_factor": resolved_yield,
             "uncertainty_margin": margin,
             "area_proxy_used": area_cm2 is None,
+            "area_source": "proxy" if area_cm2 is None else "direct_input",
             "memory_bits": memory_bits,
             "bitcell_area_um2": bitcell_area_um2,
             "area_scaling_factor": scaling,
+            "design_area_multiplier": scaling,
         },
     }
 
@@ -153,6 +172,23 @@ def estimate_operational_carbon(
     lifetime_cfg = calib["lifetime_defaults"]
 
     energy_per_unit_j = float(_as_float(energy_joules, "energy_joules"))
+
+    scaling_inputs = {
+        "total_accesses": total_accesses,
+        "workload_repetitions": workload_repetitions,
+        "accesses_per_day": accesses_per_day,
+        "years": years,
+    }
+    if lifetime_energy_joules is not None and any(v is not None for v in scaling_inputs.values()):
+        raise ValueError(
+            "Ambiguous workload specification: lifetime_energy_joules cannot be combined with total_accesses, workload_repetitions, years, or accesses_per_day"
+        )
+    if total_accesses is not None and workload_repetitions is not None:
+        raise ValueError("Ambiguous workload specification: provide only one of total_accesses or workload_repetitions")
+    if total_accesses is not None and (years is not None or accesses_per_day is not None):
+        raise ValueError("Ambiguous workload specification: total_accesses cannot be combined with years/accesses_per_day")
+    if workload_repetitions is not None and (years is not None or accesses_per_day is not None):
+        raise ValueError("Ambiguous workload specification: workload_repetitions cannot be combined with years/accesses_per_day")
     if lifetime_energy_joules is not None:
         total_energy_j = float(_as_float(lifetime_energy_joules, "lifetime_energy_joules"))
         lifetime_mode = "explicit_lifetime_energy"
@@ -163,8 +199,8 @@ def estimate_operational_carbon(
         total_energy_j = energy_per_unit_j * float(_as_float(workload_repetitions, "workload_repetitions"))
         lifetime_mode = "workload_repetitions"
     else:
-        yrs = float(_as_float(years if years is not None else lifetime_cfg.get("years", 1.0), "years"))
-        apd = float(_as_float(accesses_per_day if accesses_per_day is not None else lifetime_cfg.get("accesses_per_day", 1.0), "accesses_per_day"))
+        yrs = _as_positive(years if years is not None else lifetime_cfg.get("years", 1.0), "years")
+        apd = _as_positive(accesses_per_day if accesses_per_day is not None else lifetime_cfg.get("accesses_per_day", 1.0), "accesses_per_day")
         total_energy_j = energy_per_unit_j * apd * 365.0 * yrs
         lifetime_mode = "accesses_per_day_and_years"
 
@@ -174,8 +210,10 @@ def estimate_operational_carbon(
             available = ", ".join(sorted(regions.keys()))
             raise ValueError(f"Unknown grid_region={grid_region}; available: {available}")
         grid_factor = float(regions[grid_region])
+        grid_override_used = False
     else:
         grid_factor = float(_as_float(grid_factor_kgco2e_per_kwh, "grid_factor_kgco2e_per_kwh"))
+        grid_override_used = True
 
     best_grid = float(
         _as_float(
@@ -203,11 +241,16 @@ def estimate_operational_carbon(
         "lifetime_energy_joules": total_energy_j,
         "assumptions": {
             "grid_region": grid_region,
+            "requested_grid_region": grid_region,
             "grid_factor_kgco2e_per_kwh": grid_factor,
+            "grid_factor_override_used": grid_override_used,
+            "grid_region_provenance": grid_cfg.get("region_provenance", {}).get(grid_region, "unspecified"),
+            "grid_scenario_provenance": grid_cfg.get("scenario_provenance", "unspecified"),
             "best_grid_factor_kgco2e_per_kwh": best_grid,
             "worst_grid_factor_kgco2e_per_kwh": worst_grid,
             "lifetime_mode": lifetime_mode,
             "energy_joules_per_unit": energy_per_unit_j,
+            "dynamic_carbon_scope": "lifetime",
         },
     }
 
@@ -289,6 +332,17 @@ def estimate_carbon_bounds(
 
     return {
         "nominal": nominal,
+        "uncertainty": {
+            "static_carbon_kgco2e": {
+                "lower_bound_kgco2e": embodied["lower_bound_kgco2e"],
+                "upper_bound_kgco2e": embodied["upper_bound_kgco2e"],
+            },
+            "total_carbon_kgco2e": {
+                "lower_bound_kgco2e": embodied["lower_bound_kgco2e"] + operational["nominal_kgco2e"],
+                "upper_bound_kgco2e": embodied["upper_bound_kgco2e"] + operational["nominal_kgco2e"],
+            },
+            "uncertainty_margin": embodied["assumptions"]["uncertainty_margin"],
+        },
         "best_case": best_case,
         "worst_case": worst_case,
         "assumptions": {

--- a/docs/carbon_calibration.md
+++ b/docs/carbon_calibration.md
@@ -1,10 +1,16 @@
 # Carbon Calibration Model
 
-This repository now includes a calibrated carbon subsystem in `carbon_model.py` with calibration data in `carbon_calib.json`.
+This repository includes a calibrated carbon subsystem in `carbon_model.py` with calibration data in `carbon_calib.json`.
+
+## Scope and precision
+
+- **Operational carbon** is calibrated from measured/estimated energy and a grid emission factor.
+- **Embodied carbon** is a **proxy-calibrated** estimate from effective area, node intensity defaults, and yield assumptions.
+- These outputs are suitable for comparative design analysis, but they are **not** a full process-flow LCA.
 
 ## Model split
 
-- **Static carbon (embodied/manufacturing):**
+- **Static carbon (embodied/manufacturing proxy):**
   - `static_carbon_kgco2e = area_cm2 * fab_intensity_kgco2e_per_cm2 * yield_loss_factor`
 - **Dynamic carbon (operational/use-phase):**
   - `energy_kwh = energy_joules / 3.6e6`
@@ -20,33 +26,46 @@ This repository now includes a calibrated carbon subsystem in `carbon_model.py` 
   - fabrication intensity min/nominal/max
   - yield factors
   - uncertainty margin
+  - `design_area_multiplier` (currently 1.0 across nodes; placeholder to keep area scaling explicit)
 - grid defaults:
-  - region factors (`global_avg`, `india`, `us`, `europe`, `brazil`, `iceland`)
-  - explicit best/worst case grid factors
+  - region-average factors (`global_avg`, `india`, `us`, `europe`, `brazil`, `iceland`)
+  - `global_avg = 0.301` kgCO2e/kWh (region-average default)
+  - scenario-only best/worst factors used for stress envelopes (not region averages)
+  - provenance metadata for region and scenario factors
 - lifetime defaults:
   - years and accesses per day
 
-## Bounds and uncertainty
+## Node and area assumptions transparency
 
-`estimate_carbon_bounds(...)` returns:
+When a node is not directly calibrated (for example 14nm), the model maps to the nearest calibrated node and reports:
 
-- `nominal`
-- `best_case`
-- `worst_case`
-- `assumptions`
+- `requested_node_nm`
+- `calibrated_node_nm`
+- `node_mapping_mode` (`exact` or `nearest_calibrated`)
 
-Best-case combines lower intensity/yield penalty and greener grid. Worst-case combines higher intensity/yield penalty and dirtier grid.
+Area assumptions report whether area was direct input or derived from a memory-bit proxy (`area_source`, `area_proxy_used`).
+
+## Bounds vs scenarios
+
+`estimate_carbon_bounds(...)` returns separate concepts:
+
+- `nominal`: nominal static/dynamic/total values
+- `uncertainty`: symmetric uncertainty bounds (± margin around nominal embodied term)
+- `best_case`: scenario minimums using greener grid and lower node/yield intensity assumptions
+- `worst_case`: scenario maximums using dirtier grid and higher node/yield intensity assumptions
+
+Uncertainty bounds are not equivalent to scenario best/worst envelopes.
 
 ## ECC selector integration
 
-`ecc_selector.select(...)` supports optional carbon policies (default behavior unchanged):
+`ecc_selector.select(...)` supports optional carbon policies (default behavior unchanged when omitted or `None`):
 
 - `minimum_total_carbon`
 - `minimum_dynamic_carbon`
 - `minimum_static_carbon`
 - `balanced_carbon_energy`
 
-Each candidate record now includes:
+With a carbon policy, candidate records include:
 
 - `static_carbon_kgco2e`
 - `dynamic_carbon_kgco2e`

--- a/tests/python/test_carbon_model.py
+++ b/tests/python/test_carbon_model.py
@@ -2,6 +2,7 @@ import math
 
 import pytest
 
+import ecc_selector
 from carbon_model import (
     JOULES_PER_KWH,
     estimate_embodied_carbon,
@@ -63,6 +64,7 @@ def test_uncertainty_bounds_correctness():
     assert emb["lower_bound_kgco2e"] == pytest.approx(emb["nominal_kgco2e"] * 0.8)
     assert emb["upper_bound_kgco2e"] == pytest.approx(emb["nominal_kgco2e"] * 1.2)
     assert emb["best_case_kgco2e"] <= emb["worst_case_kgco2e"]
+    assert emb["best_case_kgco2e"] != pytest.approx(emb["lower_bound_kgco2e"])
 
 
 def test_region_override_correctness():
@@ -84,6 +86,194 @@ def test_selector_carbon_policy_integration():
     best = result["best"]
     dynamic_vals = [r["dynamic_carbon_kgco2e"] for r in result["candidate_records"]]
     assert best["dynamic_carbon_kgco2e"] == pytest.approx(min(dynamic_vals))
+
+
+def test_node_mapping_metadata_for_uncalibrated_node():
+    emb = estimate_embodied_carbon(node_nm=14, area_cm2=0.2)
+    assumptions = emb["assumptions"]
+    assert assumptions["requested_node_nm"] == 14
+    assert assumptions["calibrated_node_nm"] == 16
+    assert assumptions["node_mapping_mode"] == "nearest_calibrated"
+
+
+def test_invalid_inputs_raise_clean_errors():
+    with pytest.raises(ValueError, match="energy_joules must be non-negative"):
+        estimate_operational_carbon(energy_joules=-1.0)
+    with pytest.raises(ValueError, match="area_cm2 must be non-negative"):
+        estimate_embodied_carbon(node_nm=16, area_cm2=-0.1)
+    with pytest.raises(ValueError, match="years must be positive"):
+        estimate_operational_carbon(energy_joules=1.0, years=0)
+    with pytest.raises(ValueError, match="accesses_per_day must be positive"):
+        estimate_operational_carbon(energy_joules=1.0, accesses_per_day=0)
+    with pytest.raises(ValueError, match="Unknown grid_region=moon"):
+        estimate_operational_carbon(energy_joules=1.0, grid_region="moon")
+    with pytest.raises(ValueError, match="fab_intensity_kgco2e_per_cm2 must be positive"):
+        estimate_embodied_carbon(node_nm=16, area_cm2=0.1, fab_intensity_kgco2e_per_cm2=0)
+    with pytest.raises(ValueError, match="yield_loss_factor must be positive"):
+        estimate_embodied_carbon(node_nm=16, area_cm2=0.1, yield_loss_factor=0)
+    with pytest.raises(ValueError, match="Ambiguous workload specification"):
+        estimate_operational_carbon(energy_joules=1.0, lifetime_energy_joules=10.0, total_accesses=2)
+
+
+def test_uncertainty_separate_from_scenario_bounds():
+    bounds = estimate_carbon_bounds(node_nm=16, area_cm2=0.1, energy_joules=1000.0, total_accesses=100)
+    assert "uncertainty" in bounds
+    assert bounds["uncertainty"]["static_carbon_kgco2e"]["lower_bound_kgco2e"] < bounds["nominal"]["static_carbon_kgco2e"]
+    assert bounds["best_case"]["static_carbon_kgco2e"] <= bounds["worst_case"]["static_carbon_kgco2e"]
+    assert bounds["uncertainty"]["static_carbon_kgco2e"]["lower_bound_kgco2e"] != pytest.approx(
+        bounds["best_case"]["static_carbon_kgco2e"]
+    )
+
+
+def test_selector_default_behavior_unchanged_without_policy():
+    codes = ["sec-ded-64", "sec-daec-64", "taec-64"]
+    omitted = select(codes, **_selector_params())
+    explicit_none = select(codes, carbon_policy=None, **_selector_params())
+    assert omitted["best"]["code"] == explicit_none["best"]["code"]
+    for rec in omitted["candidate_records"]:
+        assert "dynamic_carbon_kgco2e" not in rec
+        assert "static_carbon_kgco2e" not in rec
+
+
+def test_selector_carbon_policy_routes_ranking_logic(monkeypatch):
+    base = {
+        "sram-secded-8": {
+            "FIT": 10.0,
+            "ESII": 1.0,
+            "carbon_kg": 5.0,
+            "E_dyn_kWh": 1.0,
+            "E_leak_kWh": 0.0,
+            "E_scrub_kWh": 0.0,
+            "latency_ns": 1.0,
+            "latency_base_ns": 0.0,
+            "area_logic_mm2": 5.0,
+            "area_macro_mm2": 0.0,
+            "notes": "",
+            "includes_scrub_energy": True,
+            "fit_bit": 1.0,
+            "fit_word_post": 1.0,
+            "flux_rel": 1.0,
+        },
+        "sram-bch-32": {
+            "FIT": 12.0,
+            "ESII": 1.0,
+            "carbon_kg": 4.0,
+            "E_dyn_kWh": 3.0,
+            "E_leak_kWh": 0.0,
+            "E_scrub_kWh": 0.0,
+            "latency_ns": 1.0,
+            "latency_base_ns": 0.0,
+            "area_logic_mm2": 1.0,
+            "area_macro_mm2": 0.0,
+            "notes": "",
+            "includes_scrub_energy": True,
+            "fit_bit": 1.0,
+            "fit_word_post": 1.0,
+            "flux_rel": 1.0,
+        },
+        "polar-128-96": {
+            "FIT": 11.0,
+            "ESII": 1.0,
+            "carbon_kg": 6.0,
+            "E_dyn_kWh": 2.0,
+            "E_leak_kWh": 0.0,
+            "E_scrub_kWh": 0.0,
+            "latency_ns": 1.0,
+            "latency_base_ns": 0.0,
+            "area_logic_mm2": 2.0,
+            "area_macro_mm2": 0.0,
+            "notes": "",
+            "includes_scrub_energy": True,
+            "fit_bit": 1.0,
+            "fit_word_post": 1.0,
+            "flux_rel": 1.0,
+        },
+    }
+
+    def _fake_metrics(code, **kwargs):
+        return {"code": code, **base[code]}
+
+    def _fake_bounds(*, area_cm2, energy_joules, **kwargs):
+        return {
+            "nominal": {
+                "static_carbon_kgco2e": area_cm2 * 100.0,
+                "dynamic_carbon_kgco2e": energy_joules / 3_600_000.0,
+                "total_carbon_kgco2e": area_cm2 * 100.0 + energy_joules / 3_600_000.0,
+            },
+            "best_case": {"static_carbon_kgco2e": 0.0, "dynamic_carbon_kgco2e": 0.0, "total_carbon_kgco2e": 0.0},
+            "worst_case": {"static_carbon_kgco2e": 1.0, "dynamic_carbon_kgco2e": 1.0, "total_carbon_kgco2e": 2.0},
+            "assumptions": {},
+        }
+
+    monkeypatch.setattr(ecc_selector, "_compute_metrics", _fake_metrics)
+    monkeypatch.setattr(ecc_selector, "_annotate_gs", lambda recs, weights: None)
+    monkeypatch.setattr(ecc_selector, "estimate_carbon_bounds", _fake_bounds)
+    codes = ["sram-secded-8", "sram-bch-32", "polar-128-96"]
+    params = _selector_params()
+    winners = {
+        "minimum_dynamic_carbon": select(codes, carbon_policy="minimum_dynamic_carbon", **params)["best"]["code"],
+        "minimum_static_carbon": select(codes, carbon_policy="minimum_static_carbon", **params)["best"]["code"],
+        "minimum_total_carbon": select(codes, carbon_policy="minimum_total_carbon", **params)["best"]["code"],
+        "balanced_carbon_energy": select(codes, carbon_policy="balanced_carbon_energy", **params)["best"]["code"],
+    }
+    assert len(set(winners.values())) >= 2
+
+
+def test_selector_policy_routing_uses_policy_specific_metrics(monkeypatch):
+    def _fake_bounds(*, area_cm2, energy_joules, **kwargs):
+        # Force a tradeoff so static/dynamic minima differ across candidates.
+        static = area_cm2 * 100.0
+        dynamic = 1000.0 / max(area_cm2, 1e-9)
+        return {
+            "nominal": {
+                "static_carbon_kgco2e": static,
+                "dynamic_carbon_kgco2e": dynamic,
+                "total_carbon_kgco2e": static + dynamic,
+            },
+            "best_case": {
+                "static_carbon_kgco2e": static,
+                "dynamic_carbon_kgco2e": dynamic,
+                "total_carbon_kgco2e": static + dynamic,
+            },
+            "worst_case": {
+                "static_carbon_kgco2e": static,
+                "dynamic_carbon_kgco2e": dynamic,
+                "total_carbon_kgco2e": static + dynamic,
+            },
+            "assumptions": {},
+        }
+
+    monkeypatch.setattr(ecc_selector, "estimate_carbon_bounds", _fake_bounds)
+    codes = ["sram-secded-8", "sram-bch-32", "polar-128-96"]
+    params = _selector_params()
+
+    dynamic_pick = select(codes, carbon_policy="minimum_dynamic_carbon", **params)
+    static_pick = select(codes, carbon_policy="minimum_static_carbon", **params)
+
+    assert dynamic_pick["best"]["code"] != static_pick["best"]["code"]
+
+
+def test_zero_edge_cases_are_safe():
+    op = estimate_operational_carbon(energy_joules=0.0, total_accesses=10)
+    assert op["nominal_kgco2e"] == pytest.approx(0.0)
+    emb = estimate_embodied_carbon(node_nm=16, area_cm2=0.0)
+    assert emb["nominal_kgco2e"] == pytest.approx(0.0)
+    bounds = estimate_carbon_bounds(node_nm=16, area_cm2=0.0, energy_joules=0.0, total_accesses=1)
+    score = carbon_breakdown(bounds=bounds)
+    assert score["total_carbon_kgco2e"] == pytest.approx(0.0)
+    assert score["static_fraction"] == pytest.approx(0.0)
+    assert score["dynamic_fraction"] == pytest.approx(0.0)
+
+
+def test_unit_consistency_and_lifetime_scaling():
+    assert JOULES_PER_KWH == pytest.approx(3.6e6)
+    op_1kwh = estimate_operational_carbon(energy_joules=JOULES_PER_KWH, lifetime_energy_joules=JOULES_PER_KWH, grid_factor_kgco2e_per_kwh=1.0)
+    assert op_1kwh["energy_kwh"] == pytest.approx(1.0)
+    op_3600j = estimate_operational_carbon(energy_joules=3600.0, lifetime_energy_joules=3600.0, grid_factor_kgco2e_per_kwh=1.0)
+    assert op_3600j["energy_kwh"] == pytest.approx(0.001)
+    op_a = estimate_operational_carbon(energy_joules=20.0, total_accesses=10, grid_factor_kgco2e_per_kwh=1.0)
+    op_b = estimate_operational_carbon(energy_joules=20.0, total_accesses=20, grid_factor_kgco2e_per_kwh=1.0)
+    assert op_b["nominal_kgco2e"] == pytest.approx(op_a["nominal_kgco2e"] * 2.0)
 
 
 def test_carbon_breakdown_schema_and_fractions():


### PR DESCRIPTION
### Motivation
- Correct a provenance/numbering mismatch and make grid-factor defaults defensible by changing `global_avg` to `0.301` and making provenance explicit. 
- Make node fallback behavior explicit and traceable so uncalibrated nodes are not silently remapped. 
- Improve input validation and deterministic error behavior for lifetime/workload and positive-only parameters to avoid ambiguous or silent failures. 
- Separate symmetric uncertainty bounds from scenario best/worst envelopes and strengthen selector-policy testing so policies actually affect ranking logic.

### Description
- Updated calibration file `carbon_calib.json` to set `global_avg` to `0.301`, add `region_provenance`/`scenario_provenance`, and rename the placeholder `area_scaling_factor` to `design_area_multiplier` (neutral `1.0`).
- Hardened `carbon_model.py` by adding `_as_positive`, explicit node resolution that returns both `node_cfg` and `node_meta` including `requested_node_nm`, `calibrated_node_nm`, and `node_mapping_mode`, clearer `area_source` metadata, grid provenance/override flags, and deterministic `ValueError` checks for ambiguous workload combinations and non-positive lifetime/access inputs.
- Adjusted embodied-carbon math so scenario `best_case`/`worst_case` come from min/max node intensity and yield, while symmetric uncertainty bounds are reported separately in a new `uncertainty` section in `estimate_carbon_bounds` (no longer conflated with best/worst scenarios).
- Strengthened tests and docs: added/updated unit tests in `tests/python/test_carbon_model.py` (node mapping, invalid inputs, uncertainty vs scenario separation, selector default vs policy-driven behavior, zero-edge safety, unit conversions and lifetime linearity), updated `docs/carbon_calibration.md` to clarify proxy scope and assumptions, and updated README examples to use `ci = 0.301`.

### Testing
- Ran `make` and `make test` successfully to build native components and run C++ smoke tests and Python tests, and observed C++ smoke tests and Python smoke tests pass.
- Ran `python3 -m pytest -q` (full suite) and `python3 -m pytest -q tests/python/test_carbon_model.py` and observed all tests passed; local results: `206 passed` for full suite and `15 passed` for the carbon-model tests in this environment.
- All added/updated automated tests passed in the CI-like local run; no failing tests remain after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acdf9c9884832e85d4c66c5f4211f7)