### PR TITLE
Populate ECC names and stabilize carbon values for plotting

### DIFF
--- a/integrated_toolkit.py
+++ b/integrated_toolkit.py
@@ -180,6 +180,15 @@ def _plot_scatter(rows: list[dict[str, Any]], x: str, y: str, out: Path, title: 
     plt.close(fig)
 
 
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def evaluate_toolkit(inp: ToolkitInput) -> dict[str, Any]:
     _validate(inp)
     dirs = _mkdirs(inp.output_dir)
@@ -187,6 +196,7 @@ def evaluate_toolkit(inp: ToolkitInput) -> dict[str, Any]:
     codes, evaluated, known_not_evaluated = _candidate_codes(inp.word_length_bits)
     if not codes:
         raise ValueError("No implemented ECC codes for this word length")
+    code_to_name = {item["selector_code"]: item["ecc_name"] for item in evaluated}
 
     rows: list[dict[str, Any]] = []
     unsupported_fault_modes: list[str] = []
@@ -215,13 +225,18 @@ def evaluate_toolkit(inp: ToolkitInput) -> dict[str, Any]:
         for rec in res.get("candidate_records", []):
             e_kwh = float(rec.get("E_dyn_kWh", 0.0)) + float(rec.get("E_leak_kWh", 0.0)) + float(rec.get("E_scrub_kWh", 0.0))
             operational_carbon = inp.carbon_intensity_kgco2_per_kwh * e_kwh
-            embodied = max(0.0, float(rec.get("carbon_kg", 0.0)) - operational_carbon)
+            total_carbon = _safe_float(rec.get("carbon_kg"))
+            if total_carbon is None:
+                total_carbon = operational_carbon
+            embodied = max(0.0, total_carbon - operational_carbon)
+            code = rec.get("code")
+            ecc_name = rec.get("family") or code_to_name.get(code)
             rows.append(
                 {
                     "run_id": res.get("scenario_hash"),
-                    "ecc_name": rec.get("family"),
-                    "ecc_family": rec.get("family"),
-                    "code": rec.get("code"),
+                    "ecc_name": ecc_name,
+                    "ecc_family": ecc_name,
+                    "code": code,
                     "fault_mode": fault_mode,
                     "fault_model_requested": fault_mode,
                     "fault_model_simulated": "selector_mbu_class",
@@ -241,7 +256,7 @@ def evaluate_toolkit(inp: ToolkitInput) -> dict[str, Any]:
                     "gate_overhead": None,
                     "operational_carbon_kgco2e": operational_carbon,
                     "embodied_carbon_kgco2e": embodied,
-                    "total_carbon_kgco2e": rec.get("carbon_kg"),
+                    "total_carbon_kgco2e": total_carbon,
                     "grid_score": inp.grid_score,
                     "carbon_intensity": inp.carbon_intensity_kgco2_per_kwh,
                     "GREEN_Score": rec.get("GS"),

--- a/tests/python/test_integrated_toolkit_cli.py
+++ b/tests/python/test_integrated_toolkit_cli.py
@@ -70,3 +70,39 @@ def test_compare_from_config(tmp_path: Path):
     payload = json.loads(res.stdout)
     assert payload["evaluated_schemes"] >= 1
     assert (outdir / "tables" / "ecc_comparison_full.csv").exists()
+
+
+def test_evaluate_populates_ecc_name_and_carbon_fields(tmp_path: Path):
+    outdir = tmp_path / "run3"
+    _run(
+        "evaluate",
+        "--capacity",
+        "32",
+        "--word-length",
+        "16",
+        "--node",
+        "28",
+        "--vdd",
+        "0.75",
+        "--temp",
+        "100",
+        "--ber",
+        "1e-12",
+        "--altitude",
+        "5",
+        "--fault-modes",
+        "sbu",
+        "dbu",
+        "mbu",
+        "burst",
+        "--ci",
+        "0.55",
+        "--grid-score",
+        "0.75",
+        "--outdir",
+        str(outdir),
+    )
+    rows = json.loads((outdir / "data" / "all_candidates.json").read_text(encoding="utf-8"))
+    assert rows
+    assert all(row.get("ecc_name") for row in rows)
+    assert all(row.get("total_carbon_kgco2e") is not None for row in rows)


### PR DESCRIPTION
### Motivation
- Categorical plots like "Carbon vs ECC" and "Energy vs ECC" were blank when candidate rows lacked `ecc_name` or had `total_carbon_kgco2e` as null, causing confusing outputs for some user scenarios.
- The evaluation output must be robust to missing/non-numeric selector fields so every run produces consistent reportable rows and plots.

### Description
- Added `_safe_float(value)` to coerce numeric selector outputs and return `None` for non-numeric inputs to avoid exceptions when parsing `carbon_kg`.
- Built a `code_to_name` mapping from the `evaluated` list and use it as a fallback to populate `ecc_name`/`ecc_family` when `rec.get("family")` is missing, and ensure `code` is recorded consistently in each row.
- Added fallback logic to set `total_carbon_kgco2e` to computed operational carbon when selector `carbon_kg` is missing or invalid, and compute `embodied_carbon_kgco2e` accordingly.
- Added a regression test `test_evaluate_populates_ecc_name_and_carbon_fields` in `tests/python/test_integrated_toolkit_cli.py` to assert non-empty `ecc_name` and non-null `total_carbon_kgco2e` for a multi-fault 16-bit evaluation.

### Testing
- Ran the targeted test module with `python3 -m pytest -q tests/python/test_integrated_toolkit_cli.py` and it passed (3 passed).
- Built and ran the full test matrix with `make`, `make test`, and `python3 -m pytest -q`, which succeeded (full suite: 217 passed, 3 warnings in this run).
- Performed a manual evaluation with `python3 eccsim.py evaluate --capacity 32 --word-length 16 --node 28 --vdd 0.75 --temp 100 --ber 1e-12 --altitude 5 --fault-modes sbu dbu mbu burst --ci 0.55 --grid-score 0.75 --outdir /tmp/ecc_run_fix` and verified `/tmp/ecc_run_fix/data/all_candidates.json` contained no missing `ecc_name` entries and no null `total_carbon_kgco2e` entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae24e8f7c8832ea7de53c71c47ee39)