### PR TITLE
Improve actionable CLI errors for missing ECC artifacts

### DIFF
--- a/eccsim.py
+++ b/eccsim.py
@@ -723,16 +723,20 @@ def main() -> None:
                 print(f"{key}: {artifacts[key]}")
         elif args.ml_command == "split-dataset":
             from ml.splits import create_deterministic_splits
-
-            split_path = create_deterministic_splits(
-                args.dataset,
-                args.out,
-                seed=args.seed,
-                train_ratio=args.train_ratio,
-                validation_ratio=args.validation_ratio,
-                holdout_ratio=args.holdout_ratio,
-                group_column=args.group_column,
-            )
+            try:
+                split_path = create_deterministic_splits(
+                    args.dataset,
+                    args.out,
+                    seed=args.seed,
+                    train_ratio=args.train_ratio,
+                    validation_ratio=args.validation_ratio,
+                    holdout_ratio=args.holdout_ratio,
+                    group_column=args.group_column,
+                )
+            except FileNotFoundError as exc:
+                ml_split.error(
+                    f"{exc}. Run `ml build-dataset --from <artifacts_dir> --out {args.dataset}` first."
+                )
             print(f"splits: {split_path}")
         elif args.ml_command == "train":
             from ml.train import train_models
@@ -944,8 +948,13 @@ def main() -> None:
             classify_archetypes(args.from_csv, args.out)
         elif args.analyze_command == "surface":
             from analysis.surface import analyze_surface
-
-            analyze_surface(args.cand_csv, args.out_csv, args.plot)
+            try:
+                analyze_surface(args.cand_csv, args.out_csv, args.plot)
+            except FileNotFoundError as exc:
+                surface_parser.error(
+                    f"{exc}. Generate candidates first via `select --emit-candidates <path>` "
+                    "or point --from-candidates to an existing CSV."
+                )
         elif args.analyze_command == "sensitivity":
             from analysis.sensitivity import analyze_sensitivity
             if (args.factor2 is None) != (args.grid2 is None):
@@ -1486,7 +1495,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
 
 
 

--- a/ml/dataset.py
+++ b/ml/dataset.py
@@ -184,7 +184,11 @@ def _collect_training_rows(
             sources.append(str(path))
 
     if not rows:
-        raise ValueError(f"No usable CSV rows found under {from_dir}")
+        raise ValueError(
+            "No usable CSV rows found under "
+            f"{from_dir}. Expected candidate/surface CSV artifacts (for example "
+            "results/<run>/data/all_candidates.csv)."
+        )
 
     # Scenario-level label policy.
     groups: dict[str, list[dict[str, object]]] = {}

--- a/tests/python/test_cli_error_messages.py
+++ b/tests/python/test_cli_error_messages.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "eccsim.py"
+
+
+def test_analyze_surface_missing_candidates_has_actionable_error(tmp_path: Path) -> None:
+    missing = tmp_path / "candidates.csv"
+    out_csv = tmp_path / "surface.csv"
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "analyze",
+        "surface",
+        "--from-candidates",
+        str(missing),
+        "--out-csv",
+        str(out_csv),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert res.returncode != 0
+    assert "Generate candidates first via `select --emit-candidates <path>`" in res.stderr
+
+
+def test_ml_split_dataset_missing_dataset_has_actionable_error(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "ml_dataset"
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "ml",
+        "split-dataset",
+        "--dataset",
+        str(dataset_dir),
+    ]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert res.returncode != 0
+    assert "Run `ml build-dataset --from <artifacts_dir> --out" in res.stderr


### PR DESCRIPTION
### Motivation

- Users invoking ML and analysis subcommands were seeing raw Python tracebacks when required CSV artifacts were missing instead of actionable guidance.
- Provide clear next steps while preserving existing output/schema and backward compatibility.

### Description

- Improve the empty-input error in `ml/dataset.py` to explain which CSV artifacts are expected, including an example path (`results/<run>/data/all_candidates.csv`).
- Catch `FileNotFoundError` in the `ml split-dataset` handling in `eccsim.py` and convert the traceback into a parser error with a suggested command (`ml build-dataset --from <artifacts_dir> --out <dataset>`).
- Catch `FileNotFoundError` in the `analyze surface` CLI path in `eccsim.py` and convert the traceback into a parser error advising to generate candidates via `select --emit-candidates <path>` or point `--from-candidates` to an existing CSV.
- Add `tests/python/test_cli_error_messages.py` with CLI tests that assert the new actionable error messages for both missing-file scenarios.

### Testing

- Ran `make` and `make test` which built native helpers and ran the smoke tests; all smoke checks passed.
- Ran the full Python test suite with `python3 -m pytest -q`; the test run passed (219 passed, 3 warnings).
- The new CLI tests in `tests/python/test_cli_error_messages.py` were executed as part of the test suite and verified the intended error messages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae87a540d4832eb6a9b9ff138df27a)