### PR TITLE
Add ASIC-oriented pure SystemVerilog ECC implementation under asic/

### DIFF
--- a/asic/docs/MODULE_MAP.md
+++ b/asic/docs/MODULE_MAP.md
@@ -1,0 +1,34 @@
+# ECC Entry -> RTL Mapping
+
+| code_db_entry | rtl_family | encoder_module | decoder_module | wrapper_module | tb_module |
+|---|---|---|---|---|---|
+| sec-ded-64 | SEC-DED | secded_encoder(DATA_W=64) | secded_decoder(DATA_W=64) | sec_ded_64 | tb_secded |
+| sec-daec-64 | SEC-DAEC | secdaec_encoder(DATA_W=64) | secdaec_decoder(DATA_W=64) | sec_daec_64 | tb_secdaec |
+| taec-64 | TAEC | taec_encoder(DATA_W=64) | taec_decoder(DATA_W=64) | taec_64 | tb_taec |
+| bch-63 | BCH | bch_encoder(N=63,K=51) | bch_decoder(N=63,K=51) | bch_63 | tb_bch |
+| polar-64-32 | Polar | polar_encoder(N=64,K=32) | polar_decoder(N=64,K=32) | polar_64_32 | tb_polar |
+| polar-64-48 | Polar | polar_encoder(N=64,K=48) | polar_decoder(N=64,K=48) | polar_64_48 | tb_polar |
+| polar-128-96 | Polar | polar_encoder(N=128,K=96) | polar_decoder(N=128,K=96) | polar_128_96 | tb_polar |
+| sram-secded-8 | SEC-DED | secded_encoder(DATA_W=8) | secded_decoder(DATA_W=8) | sram_secded_8 | tb_sram_wrappers |
+| sram-secded-16 | SEC-DED | secded_encoder(DATA_W=16) | secded_decoder(DATA_W=16) | sram_secded_16 | tb_sram_wrappers |
+| sram-secded-32 | SEC-DED | secded_encoder(DATA_W=32) | secded_decoder(DATA_W=32) | sram_secded_32 | tb_sram_wrappers |
+| sram-taec-8 | TAEC | taec_encoder(DATA_W=8) | taec_decoder(DATA_W=8) | sram_taec_8 | tb_sram_wrappers |
+| sram-taec-16 | TAEC | taec_encoder(DATA_W=16) | taec_decoder(DATA_W=16) | sram_taec_16 | tb_sram_wrappers |
+| sram-taec-32 | TAEC | taec_encoder(DATA_W=32) | taec_decoder(DATA_W=32) | sram_taec_32 | tb_sram_wrappers |
+| sram-bch-8 | BCH | bch_encoder(N=14,K=8) | bch_decoder(N=14,K=8) | sram_bch_8 | tb_sram_wrappers |
+| sram-bch-16 | BCH | bch_encoder(N=24,K=16) | bch_decoder(N=24,K=16) | sram_bch_16 | tb_sram_wrappers |
+| sram-bch-32 | BCH | bch_encoder(N=45,K=32) | bch_decoder(N=45,K=32) | sram_bch_32 | tb_sram_wrappers |
+| sram-polar-8 | Polar | polar_encoder(N=16,K=8) | polar_decoder(N=16,K=8) | sram_polar_8 | tb_sram_wrappers |
+| sram-polar-16 | Polar | polar_encoder(N=32,K=16) | polar_decoder(N=32,K=16) | sram_polar_16 | tb_sram_wrappers |
+| sram-polar-32 | Polar | polar_encoder(N=64,K=32) | polar_decoder(N=64,K=32) | sram_polar_32 | tb_sram_wrappers |
+
+## RTL file locations
+- `asic/include/ecc_pkg.sv`
+- `asic/rtl/common/ecc_entries.sv`
+- `asic/rtl/secded/secded_codec.sv`
+- `asic/rtl/secdaec/secdaec_codec.sv`
+- `asic/rtl/taec/taec_codec.sv`
+- `asic/rtl/bch/bch_codec.sv`
+- `asic/rtl/polar/polar_pkg.sv`
+- `asic/rtl/polar/polar_codec.sv`
+- `asic/rtl/sram/sram_wrappers.sv`

--- a/asic/docs/README_asic.md
+++ b/asic/docs/README_asic.md
@@ -1,0 +1,47 @@
+# ASIC SystemVerilog ECC Track
+
+## Directory Overview
+- `asic/include/`: common packages (`ecc_pkg.sv`).
+- `asic/rtl/common/`: shared RTL utilities and fixed-entry aliases.
+- `asic/rtl/secded/`: SEC-DED encoder/decoder.
+- `asic/rtl/secdaec/`: SEC-DAEC adjacent-double aware decoder.
+- `asic/rtl/taec/`: TAEC-style triple-adjacent-aware decoder.
+- `asic/rtl/bch/`: BCH encoder and bounded t<=2 decoder.
+- `asic/rtl/polar/`: Polar encoder and bounded hard-decision decoder.
+- `asic/rtl/sram/`: SRAM wrappers (`sram_*`).
+- `asic/tb/`: self-checking family and wrapper testbenches.
+- `asic/scripts/`: compile / run / regression scripts.
+
+## Modeling Notes by ECC Family
+- **SEC-DED**: canonical Hamming parity placement + overall parity bit. Decoder emits syndrome, correction mask, overall mismatch, and corrected codeword.
+- **SEC-DAEC**: starts from SEC-DED decode, then performs explicit adjacent data-bit pair syndrome matching to recover DAEC patterns.
+- **TAEC**: starts from SEC behavior; if unresolved and odd-parity mismatch exists, searches adjacent 3-bit windows in data domain for syndrome match.
+- **BCH**: systematic polynomial-division encoder. Decoder computes remainder syndrome and then performs bounded candidate search (0/1/2 bit flips) against valid remainder=0 check.
+- **Polar**: Arikan transform encoder with deterministic frozen mask assumption. Decoder uses transform-based estimate with frozen-bit enforcement, then bounded 1/2 info-bit local search to reduce Hamming distance.
+
+## Assumptions / Limitations
+- TAEC and Polar decoders are **bounded practical models**, not full optimum decoders.
+- BCH decoder is mathematically valid for bounded correction, but area-heavy because it performs exhaustive candidate checks.
+- Frozen-bit reliability ordering for Polar is intentionally simplified (lower indices frozen).
+- All limitations are explicit in module header comments for future enhancement.
+
+## Build and Simulation Commands
+```bash
+# compile a single testbench
+asic/scripts/compile.sh tb_secded
+
+# run one test
+asic/scripts/run.sh tb_secded
+
+# run full ASIC regression
+asic/scripts/regress.sh
+```
+
+## Debugging Notes (waveform-first signals)
+- SEC families: `syndrome_o`, `overall_mismatch_o`, `correction_mask_o`, `error_pos_o`.
+- SEC-DAEC/TAEC: `adjacent_double_corrected_o`, `triple_adjacent_corrected_o`.
+- BCH: `syndrome_o`, `corrected_codeword_o`, internal candidate search results.
+- Polar: `u_dbg_o`, `u_hat_o`, `corrected_codeword_o`, `err_*` flags.
+
+## 19-entry mapping
+See `asic/docs/MODULE_MAP.md`.

--- a/asic/include/ecc_pkg.sv
+++ b/asic/include/ecc_pkg.sv
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+// File: ecc_pkg.sv
+// Purpose: Common ECC package with status types and compile-time helper
+//          functions used across ASIC-oriented ECC RTL blocks.
+// Scheme: Common/shared infrastructure
+// Assumptions: Pure combinational helpers, no simulator-specific extensions.
+// Synthesizability: Yes (package functions are constant-time loop constructs).
+//------------------------------------------------------------------------------
+package ecc_pkg;
+
+  typedef struct packed {
+    logic detected;
+    logic corrected;
+    logic uncorrectable;
+    logic adjacent_corrected;
+    logic [15:0] error_pos;
+  } ecc_status_t;
+
+  function automatic bit is_pow2(input int unsigned v);
+    if (v == 0) return 1'b0;
+    return ((v & (v-1)) == 0);
+  endfunction
+
+  function automatic int unsigned hamming_parity_bits(input int unsigned data_w);
+    int unsigned m;
+    begin
+      m = 1;
+      while ((1 << m) < (data_w + m + 1)) m++;
+      return m;
+    end
+  endfunction
+
+  function automatic int unsigned hamming_codeword_wo_overall(input int unsigned data_w);
+    int unsigned m;
+    begin
+      m = hamming_parity_bits(data_w);
+      return data_w + m;
+    end
+  endfunction
+
+  function automatic int unsigned popcount(input logic [255:0] v, input int unsigned w);
+    int unsigned i;
+    int unsigned c;
+    begin
+      c = 0;
+      for (i = 0; i < w; i++) c += v[i];
+      return c;
+    end
+  endfunction
+
+endpackage

--- a/asic/rtl/bch/bch_codec.sv
+++ b/asic/rtl/bch/bch_codec.sv
@@ -1,0 +1,117 @@
+//------------------------------------------------------------------------------
+// File: bch_codec.sv
+// Purpose: Binary BCH codec (bounded t<=2 decoder via exhaustive candidate
+//          search on valid codeword remainder check).
+// Scheme: BCH (n=63 default)
+// Assumptions: Systematic encoder using generator polynomial G_POLY.
+//              Decoder is intentionally bounded to <=2 bit corrections.
+// Synthesizability: Yes, but decoder area is high due to exhaustive search.
+//------------------------------------------------------------------------------
+module bch_encoder #(
+  parameter int N = 63,
+  parameter int K = 51,
+  parameter int R = N-K,
+  parameter logic [R:0] G_POLY = 13'b1_000111101011 // degree-12 example
+) (
+  input  logic [K-1:0] data_i,
+  output logic [N-1:0] codeword_o
+);
+  int i, j;
+  logic [N-1:0] work;
+
+  always_comb begin
+    work = '0;
+    work[N-1 -: K] = data_i;
+
+    for (i = N-1; i >= R; i--) begin
+      if (work[i]) begin
+        for (j = 0; j <= R; j++) begin
+          work[i-j] ^= G_POLY[R-j];
+        end
+      end
+    end
+
+    codeword_o = '0;
+    codeword_o[N-1 -: K] = data_i;
+    codeword_o[R-1:0] = work[R-1:0];
+  end
+endmodule
+
+module bch_decoder #(
+  parameter int N = 63,
+  parameter int K = 51,
+  parameter int R = N-K,
+  parameter logic [R:0] G_POLY = 13'b1_000111101011
+) (
+  input  logic [N-1:0] codeword_i,
+  output logic [K-1:0] data_o,
+  output logic [N-1:0] corrected_codeword_o,
+  output logic [R-1:0] syndrome_o,
+  output logic         err_detected_o,
+  output logic         err_corrected_o,
+  output logic         err_uncorrectable_o
+);
+  int i, j;
+  logic [R-1:0] rem;
+  logic [N-1:0] best_cw;
+  logic found;
+
+  function automatic logic [R-1:0] calc_remainder(input logic [N-1:0] v);
+    logic [N-1:0] w;
+    int a, b;
+    begin
+      w = v;
+      for (a = N-1; a >= R; a--) begin
+        if (w[a]) begin
+          for (b = 0; b <= R; b++) w[a-b] ^= G_POLY[R-b];
+        end
+      end
+      return w[R-1:0];
+    end
+  endfunction
+
+  always_comb begin
+    rem = calc_remainder(codeword_i);
+    syndrome_o = rem;
+    err_detected_o = (rem != '0);
+    err_corrected_o = 1'b0;
+    err_uncorrectable_o = 1'b0;
+    found = 1'b0;
+    best_cw = codeword_i;
+
+    if (rem == '0) begin
+      found = 1'b1;
+      best_cw = codeword_i;
+    end else begin
+      // Single-bit search
+      for (i = 0; i < N; i++) begin
+        logic [N-1:0] c1;
+        c1 = codeword_i;
+        c1[i] = ~c1[i];
+        if (!found && (calc_remainder(c1) == '0)) begin
+          found = 1'b1;
+          best_cw = c1;
+          err_corrected_o = 1'b1;
+        end
+      end
+      // Double-bit search
+      for (i = 0; i < N; i++) begin
+        for (j = i+1; j < N; j++) begin
+          logic [N-1:0] c2;
+          c2 = codeword_i;
+          c2[i] = ~c2[i];
+          c2[j] = ~c2[j];
+          if (!found && (calc_remainder(c2) == '0)) begin
+            found = 1'b1;
+            best_cw = c2;
+            err_corrected_o = 1'b1;
+          end
+        end
+      end
+    end
+
+    corrected_codeword_o = best_cw;
+    data_o = best_cw[N-1 -: K];
+    if (err_detected_o && !found) err_uncorrectable_o = 1'b1;
+  end
+endmodule

--- a/asic/rtl/common/ecc_bitflip_corrector.sv
+++ b/asic/rtl/common/ecc_bitflip_corrector.sv
@@ -1,0 +1,19 @@
+//------------------------------------------------------------------------------
+// File: ecc_bitflip_corrector.sv
+// Purpose: Generic XOR correction-mask applicator.
+// Scheme: Common/shared infrastructure
+// Inputs/Outputs: in_word xor correction_mask -> out_word
+// Assumptions: correction_mask has same width as data.
+// Synthesizability: Yes.
+//------------------------------------------------------------------------------
+module ecc_bitflip_corrector #(
+  parameter int W = 72
+) (
+  input  logic [W-1:0] in_word,
+  input  logic [W-1:0] correction_mask,
+  output logic [W-1:0] out_word
+);
+  always_comb begin
+    out_word = in_word ^ correction_mask;
+  end
+endmodule

--- a/asic/rtl/common/ecc_entries.sv
+++ b/asic/rtl/common/ecc_entries.sv
@@ -1,0 +1,76 @@
+//------------------------------------------------------------------------------
+// File: ecc_entries.sv
+// Purpose: Concrete top-level module names for fixed/global code_db entries.
+// Scheme: SECDED / SECDAEC / TAEC / BCH / Polar
+// Assumptions: These are thin wiring aliases to family modules.
+// Synthesizability: Yes.
+//------------------------------------------------------------------------------
+
+module sec_ded_64 (
+  input logic [63:0] data_i,
+  output logic [71:0] codeword_o,
+  input logic [71:0] codeword_in_i,
+  output logic [63:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [6:0] pdbg, syn;
+  logic [71:0] ccw, mask;
+  logic om;
+  logic [$clog2(73)-1:0] ep;
+  secded_encoder #(.DATA_W(64)) u_e(.data_i(data_i), .codeword_o(codeword_o), .parity_dbg_o(pdbg));
+  secded_decoder #(.DATA_W(64)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(ccw), .syndrome_o(syn), .overall_mismatch_o(om), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o), .correction_mask_o(mask), .error_pos_o(ep));
+endmodule
+
+module sec_daec_64 (
+  input logic [63:0] data_i, output logic [71:0] codeword_o, input logic [71:0] codeword_in_i, output logic [63:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [71:0] ccw; logic [6:0] syn; logic adj;
+  secdaec_encoder #(.DATA_W(64)) u_e(.data_i(data_i), .codeword_o(codeword_o));
+  secdaec_decoder #(.DATA_W(64)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(ccw), .syndrome_o(syn), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o), .adjacent_double_corrected_o(adj));
+endmodule
+
+module taec_64 (
+  input logic [63:0] data_i, output logic [71:0] codeword_o, input logic [71:0] codeword_in_i, output logic [63:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [71:0] ccw; logic [6:0] syn; logic tri;
+  taec_encoder #(.DATA_W(64)) u_e(.data_i(data_i), .codeword_o(codeword_o));
+  taec_decoder #(.DATA_W(64)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(ccw), .syndrome_o(syn), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o), .triple_adjacent_corrected_o(tri));
+endmodule
+
+module bch_63 (
+  input logic [50:0] data_i, output logic [62:0] codeword_o, input logic [62:0] codeword_in_i, output logic [50:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [62:0] ccw; logic [11:0] syn;
+  bch_encoder #(.N(63), .K(51)) u_e(.data_i(data_i), .codeword_o(codeword_o));
+  bch_decoder #(.N(63), .K(51)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(ccw), .syndrome_o(syn), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule
+
+module polar_64_32 (
+  input logic [31:0] data_i, output logic [63:0] codeword_o, input logic [63:0] codeword_in_i, output logic [31:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [63:0] udbg, cwcorr, uhat;
+  polar_encoder #(.N(64), .K(32)) u_e(.data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(udbg));
+  polar_decoder #(.N(64), .K(32)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(cwcorr), .u_hat_o(uhat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule
+
+module polar_64_48 (
+  input logic [47:0] data_i, output logic [63:0] codeword_o, input logic [63:0] codeword_in_i, output logic [47:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [63:0] udbg, cwcorr, uhat;
+  polar_encoder #(.N(64), .K(48)) u_e(.data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(udbg));
+  polar_decoder #(.N(64), .K(48)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(cwcorr), .u_hat_o(uhat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule
+
+module polar_128_96 (
+  input logic [95:0] data_i, output logic [127:0] codeword_o, input logic [127:0] codeword_in_i, output logic [95:0] data_o,
+  output logic err_detected_o, err_corrected_o, err_uncorrectable_o
+);
+  logic [127:0] udbg, cwcorr, uhat;
+  polar_encoder #(.N(128), .K(96)) u_e(.data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(udbg));
+  polar_decoder #(.N(128), .K(96)) u_d(.codeword_i(codeword_in_i), .data_o(data_o), .corrected_codeword_o(cwcorr), .u_hat_o(uhat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule

--- a/asic/rtl/polar/polar_codec.sv
+++ b/asic/rtl/polar/polar_codec.sv
@@ -1,0 +1,156 @@
+//------------------------------------------------------------------------------
+// File: polar_codec.sv
+// Purpose: Polar encoder and bounded hard-decision decoder.
+// Scheme: Polar (N=64/128 supported via parameter)
+// Assumptions: Non-systematic Arikan transform. Frozen-mask default keeps lower
+//              index bits frozen. Decoder uses inverse transform + bounded
+//              local search (<=2 info-bit flips), not full SC/SCL.
+// Synthesizability: Yes (combinational), with notable area for local search.
+//------------------------------------------------------------------------------
+module polar_encoder #(
+  parameter int N = 64,
+  parameter int K = 32,
+  parameter logic [127:0] FROZEN_MASK = polar_pkg::default_frozen_mask(N,K)
+) (
+  input  logic [K-1:0] data_i,
+  output logic [N-1:0] codeword_o,
+  output logic [N-1:0] u_dbg_o
+);
+  int i, j, stage, span, half;
+  logic [N-1:0] u;
+  logic [N-1:0] x;
+
+  always_comb begin
+    u = '0;
+    j = 0;
+    for (i = 0; i < N; i++) begin
+      if (FROZEN_MASK[i]) u[i] = 1'b0;
+      else begin
+        u[i] = data_i[j];
+        j++;
+      end
+    end
+
+    x = u;
+    for (stage = 0; stage < $clog2(N); stage++) begin
+      span = (1 << (stage+1));
+      half = span >> 1;
+      for (i = 0; i < N; i += span) begin
+        for (j = 0; j < half; j++) begin
+          x[i+j] = x[i+j] ^ x[i+j+half];
+        end
+      end
+    end
+
+    u_dbg_o = u;
+    codeword_o = x;
+  end
+endmodule
+
+module polar_decoder #(
+  parameter int N = 64,
+  parameter int K = 32,
+  parameter logic [127:0] FROZEN_MASK = polar_pkg::default_frozen_mask(N,K)
+) (
+  input  logic [N-1:0] codeword_i,
+  output logic [K-1:0] data_o,
+  output logic [N-1:0] corrected_codeword_o,
+  output logic [N-1:0] u_hat_o,
+  output logic         err_detected_o,
+  output logic         err_corrected_o,
+  output logic         err_uncorrectable_o
+);
+  int i, j, stage, span, half, info_cnt;
+  logic [N-1:0] u_est;
+  logic [N-1:0] x_reenc;
+  logic [255:0] diff_vec;
+  int unsigned best_dist;
+  logic [N-1:0] best_u;
+
+  function automatic int unsigned hdist(input logic [N-1:0] a, input logic [N-1:0] b);
+    int unsigned c;
+    int t;
+    begin
+      c = 0;
+      for (t = 0; t < N; t++) c += (a[t]^b[t]);
+      return c;
+    end
+  endfunction
+
+  function automatic logic [N-1:0] polar_transform(input logic [N-1:0] in_u);
+    logic [N-1:0] y;
+    int s, p, q, sp, hf;
+    begin
+      y = in_u;
+      for (s = 0; s < $clog2(N); s++) begin
+        sp = (1 << (s+1));
+        hf = sp >> 1;
+        for (p = 0; p < N; p += sp)
+          for (q = 0; q < hf; q++) y[p+q] = y[p+q] ^ y[p+q+hf];
+      end
+      return y;
+    end
+  endfunction
+
+  always_comb begin
+    // Approximate inverse (same matrix over GF(2)).
+    u_est = polar_transform(codeword_i);
+    for (i = 0; i < N; i++) if (FROZEN_MASK[i]) u_est[i] = 1'b0;
+
+    best_u = u_est;
+    x_reenc = polar_transform(u_est);
+    best_dist = hdist(codeword_i, x_reenc);
+
+    // Bounded local search in info-bit domain (<=2 flips).
+    for (i = 0; i < N; i++) begin
+      if (!FROZEN_MASK[i]) begin
+        logic [N-1:0] c1_u, c1_x;
+        int unsigned d1;
+        c1_u = u_est;
+        c1_u[i] = ~c1_u[i];
+        c1_x = polar_transform(c1_u);
+        d1 = hdist(codeword_i, c1_x);
+        if (d1 < best_dist) begin
+          best_dist = d1;
+          best_u = c1_u;
+        end
+      end
+    end
+
+    for (i = 0; i < N; i++) begin
+      if (!FROZEN_MASK[i]) begin
+        for (j = i+1; j < N; j++) begin
+          if (!FROZEN_MASK[j]) begin
+            logic [N-1:0] c2_u, c2_x;
+            int unsigned d2;
+            c2_u = u_est;
+            c2_u[i] = ~c2_u[i];
+            c2_u[j] = ~c2_u[j];
+            c2_x = polar_transform(c2_u);
+            d2 = hdist(codeword_i, c2_x);
+            if (d2 < best_dist) begin
+              best_dist = d2;
+              best_u = c2_u;
+            end
+          end
+        end
+      end
+    end
+
+    corrected_codeword_o = polar_transform(best_u);
+    u_hat_o = best_u;
+
+    info_cnt = 0;
+    data_o = '0;
+    for (i = 0; i < N; i++) begin
+      if (!FROZEN_MASK[i]) begin
+        data_o[info_cnt] = best_u[i];
+        info_cnt++;
+      end
+    end
+
+    err_detected_o = (codeword_i != corrected_codeword_o);
+    err_corrected_o = err_detected_o && (best_dist <= 2);
+    err_uncorrectable_o = err_detected_o && (best_dist > 2);
+  end
+endmodule

--- a/asic/rtl/polar/polar_pkg.sv
+++ b/asic/rtl/polar/polar_pkg.sv
@@ -1,0 +1,19 @@
+//------------------------------------------------------------------------------
+// File: polar_pkg.sv
+// Purpose: Frozen-set helpers for predefined Polar configurations.
+// Scheme: Polar
+// Assumptions: Reliability ordering is simplified, deterministic and documented.
+// Synthesizability: Yes.
+//------------------------------------------------------------------------------
+package polar_pkg;
+  function automatic logic [127:0] default_frozen_mask(input int unsigned N, input int unsigned K);
+    logic [127:0] m;
+    int i;
+    begin
+      m = '0;
+      // Simplified reliability order assumption: keep highest indices as info bits.
+      for (i = 0; i < N-K; i++) m[i] = 1'b1; // 1 => frozen
+      return m;
+    end
+  endfunction
+endpackage

--- a/asic/rtl/secdaec/secdaec_codec.sv
+++ b/asic/rtl/secdaec/secdaec_codec.sv
@@ -1,0 +1,114 @@
+//------------------------------------------------------------------------------
+// File: secdaec_codec.sv
+// Purpose: SEC-DAEC codec built on Hamming structure with explicit adjacent
+//          double-error correction search over data-bit adjacency.
+// Scheme: SEC-DAEC
+// Assumptions: Adjacent means neighboring indices in extracted data payload.
+//              Non-adjacent double-bit errors remain uncorrectable.
+// Synthesizability: Yes (combinational bounded search).
+//------------------------------------------------------------------------------
+module secdaec_encoder #(
+  parameter int DATA_W = 64
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] codeword_o
+);
+  localparam int P_W = ecc_pkg::hamming_parity_bits(DATA_W);
+  logic [P_W-1:0] parity_dbg;
+  secded_encoder #(.DATA_W(DATA_W)) u_enc (
+    .data_i(data_i), .codeword_o(codeword_o), .parity_dbg_o(parity_dbg)
+  );
+endmodule
+
+module secdaec_decoder #(
+  parameter int DATA_W = 64,
+  parameter int P_W    = ecc_pkg::hamming_parity_bits(DATA_W),
+  parameter int N_W    = DATA_W + P_W
+) (
+  input  logic [N_W:0]      codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [N_W:0]      corrected_codeword_o,
+  output logic [P_W-1:0]    syndrome_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic              adjacent_double_corrected_o
+);
+  int i, cpos, d_idx;
+  logic [DATA_W-1:0] pre_data;
+  logic [N_W:0] secded_cw;
+  logic [P_W-1:0] syndrome;
+  logic overall_mm, det, cor, unc;
+  logic [N_W:0] mask;
+  logic [$clog2(N_W+2)-1:0] ep;
+  logic found_adj;
+  logic [N_W:0] adj_mask;
+
+  // Helper: data index -> codeword index (0-based in codeword without overall)
+  function automatic int data_idx_to_cpos0(input int unsigned data_idx);
+    int unsigned count;
+    int pos;
+    begin
+      count = 0;
+      for (pos = 1; pos <= N_W; pos++) begin
+        if (!ecc_pkg::is_pow2(pos)) begin
+          if (count == data_idx) return pos-1;
+          count++;
+        end
+      end
+      return 0;
+    end
+  endfunction
+
+  secded_decoder #(.DATA_W(DATA_W)) u_dec (
+    .codeword_i(codeword_i),
+    .data_o(pre_data),
+    .corrected_codeword_o(secded_cw),
+    .syndrome_o(syndrome),
+    .overall_mismatch_o(overall_mm),
+    .err_detected_o(det),
+    .err_corrected_o(cor),
+    .err_uncorrectable_o(unc),
+    .correction_mask_o(mask),
+    .error_pos_o(ep)
+  );
+
+  always_comb begin
+    found_adj = 1'b0;
+    adj_mask = '0;
+
+    // Only attempt DAEC rescue for standard SEC-DED double-bit signature.
+    if ((syndrome != '0) && !overall_mm) begin
+      for (i = 0; i < DATA_W-1; i++) begin
+        int p0, p1;
+        logic [P_W-1:0] pair_sig;
+        p0 = data_idx_to_cpos0(i) + 1;
+        p1 = data_idx_to_cpos0(i+1) + 1;
+        pair_sig = p0[P_W-1:0] ^ p1[P_W-1:0];
+        if (!found_adj && (pair_sig == syndrome)) begin
+          found_adj = 1'b1;
+          adj_mask[p0-1] = 1'b1;
+          adj_mask[p1-1] = 1'b1;
+        end
+      end
+    end
+
+    if (found_adj) corrected_codeword_o = codeword_i ^ adj_mask;
+    else corrected_codeword_o = secded_cw;
+
+    d_idx = 0;
+    data_o = '0;
+    for (cpos = 1; cpos <= N_W; cpos++) begin
+      if (!ecc_pkg::is_pow2(cpos)) begin
+        data_o[d_idx] = corrected_codeword_o[cpos-1];
+        d_idx++;
+      end
+    end
+
+    syndrome_o = syndrome;
+    err_detected_o = det;
+    adjacent_double_corrected_o = found_adj;
+    err_corrected_o = cor | found_adj;
+    err_uncorrectable_o = unc & ~found_adj;
+  end
+endmodule

--- a/asic/rtl/secded/secded_codec.sv
+++ b/asic/rtl/secded/secded_codec.sv
@@ -1,0 +1,127 @@
+//------------------------------------------------------------------------------
+// File: secded_codec.sv
+// Purpose: Parameterized SEC-DED encoder/decoder with explicit syndrome,
+//          correction mask, and error classification outputs.
+// Scheme: SEC-DED (Hamming + overall parity)
+// Assumptions: Standard Hamming parity placement at codeword positions that are
+//              powers of 2 (1-based), plus one overall parity bit at MSB.
+// Synthesizability: Yes (combinational datapath).
+//------------------------------------------------------------------------------
+`include "ecc_pkg.sv"
+
+module secded_encoder #(
+  parameter int DATA_W = 64,
+  parameter int P_W    = ecc_pkg::hamming_parity_bits(DATA_W),
+  parameter int N_W    = DATA_W + P_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [N_W:0]      codeword_o,
+  output logic [P_W-1:0]    parity_dbg_o
+);
+  int d_idx;
+  int p;
+  int cpos;
+  logic [N_W-1:0] code_wo_overall;
+  logic overall;
+
+  always_comb begin
+    code_wo_overall = '0;
+    d_idx = 0;
+
+    // Fill non-parity locations with data bits.
+    for (cpos = 1; cpos <= N_W; cpos++) begin
+      if (!ecc_pkg::is_pow2(cpos)) begin
+        code_wo_overall[cpos-1] = data_i[d_idx];
+        d_idx++;
+      end
+    end
+
+    // Compute each parity bit over its coverage set.
+    for (p = 0; p < P_W; p++) begin
+      logic px;
+      px = 1'b0;
+      for (cpos = 1; cpos <= N_W; cpos++) begin
+        if (cpos & (1 << p)) px ^= code_wo_overall[cpos-1];
+      end
+      code_wo_overall[(1 << p)-1] = px;
+      parity_dbg_o[p] = px;
+    end
+
+    overall = ^code_wo_overall;
+    codeword_o = {overall, code_wo_overall};
+  end
+endmodule
+
+module secded_decoder #(
+  parameter int DATA_W = 64,
+  parameter int P_W    = ecc_pkg::hamming_parity_bits(DATA_W),
+  parameter int N_W    = DATA_W + P_W
+) (
+  input  logic [N_W:0]      codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [N_W:0]      corrected_codeword_o,
+  output logic [P_W-1:0]    syndrome_o,
+  output logic              overall_mismatch_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic [N_W:0]      correction_mask_o,
+  output logic [$clog2(N_W+2)-1:0] error_pos_o
+);
+  int p, cpos, d_idx;
+  logic [P_W-1:0] syndrome;
+  logic overall_calc;
+  logic overall_mismatch;
+  int unsigned err_pos;
+
+  always_comb begin
+    syndrome = '0;
+    for (p = 0; p < P_W; p++) begin
+      logic sx;
+      sx = 1'b0;
+      for (cpos = 1; cpos <= N_W; cpos++) begin
+        if (cpos & (1 << p)) sx ^= codeword_i[cpos-1];
+      end
+      syndrome[p] = sx;
+    end
+
+    overall_calc = ^codeword_i[N_W-1:0];
+    overall_mismatch = (overall_calc != codeword_i[N_W]);
+    err_pos = syndrome;
+
+    correction_mask_o = '0;
+    err_detected_o = (syndrome != '0) || overall_mismatch;
+    err_corrected_o = 1'b0;
+    err_uncorrectable_o = 1'b0;
+
+    // SEC-DED classification
+    // 1) syndrome!=0 and overall mismatch => single-bit in payload/parity field
+    // 2) syndrome==0 and overall mismatch => overall parity-bit error only
+    // 3) syndrome!=0 and overall match    => double-bit (uncorrectable)
+    if ((syndrome != '0) && overall_mismatch) begin
+      if ((err_pos >= 1) && (err_pos <= N_W)) begin
+        correction_mask_o[err_pos-1] = 1'b1;
+        err_corrected_o = 1'b1;
+      end
+    end else if ((syndrome == '0) && overall_mismatch) begin
+      correction_mask_o[N_W] = 1'b1;
+      err_corrected_o = 1'b1;
+    end else if ((syndrome != '0) && !overall_mismatch) begin
+      err_uncorrectable_o = 1'b1;
+    end
+
+    corrected_codeword_o = codeword_i ^ correction_mask_o;
+    syndrome_o = syndrome;
+    overall_mismatch_o = overall_mismatch;
+    error_pos_o = err_pos[$clog2(N_W+2)-1:0];
+
+    d_idx = 0;
+    data_o = '0;
+    for (cpos = 1; cpos <= N_W; cpos++) begin
+      if (!ecc_pkg::is_pow2(cpos)) begin
+        data_o[d_idx] = corrected_codeword_o[cpos-1];
+        d_idx++;
+      end
+    end
+  end
+endmodule

--- a/asic/rtl/sram/sram_wrappers.sv
+++ b/asic/rtl/sram/sram_wrappers.sv
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+// File: sram_wrappers.sv
+// Purpose: Thin SRAM-facing wrappers for ECC schemes at word widths 8/16/32.
+// Scheme: SRAM wrappers over SECDED/TAEC/BCH/Polar
+// Assumptions: Write path encodes payload; read path decodes full stored word.
+// Synthesizability: Yes.
+//------------------------------------------------------------------------------
+
+module sram_secded_wrapper #(
+  parameter int DATA_W = 8
+) (
+  input  logic [DATA_W-1:0] wr_data_i,
+  output logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] mem_word_o,
+  input  logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] rd_word_i,
+  output logic [DATA_W-1:0] rd_data_o,
+  output logic err_detected_o,
+  output logic err_corrected_o,
+  output logic err_uncorrectable_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] p;
+  logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] cw_corr;
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] s;
+  logic om;
+  logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] mask;
+  logic [$clog2(DATA_W+ecc_pkg::hamming_parity_bits(DATA_W)+2)-1:0] ep;
+  secded_encoder #(.DATA_W(DATA_W)) u_we(.data_i(wr_data_i), .codeword_o(mem_word_o), .parity_dbg_o(p));
+  secded_decoder #(.DATA_W(DATA_W)) u_re(
+    .codeword_i(rd_word_i), .data_o(rd_data_o), .corrected_codeword_o(cw_corr),
+    .syndrome_o(s), .overall_mismatch_o(om), .err_detected_o(err_detected_o),
+    .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o),
+    .correction_mask_o(mask), .error_pos_o(ep));
+endmodule
+
+module sram_taec_wrapper #(
+  parameter int DATA_W = 8
+) (
+  input  logic [DATA_W-1:0] wr_data_i,
+  output logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] mem_word_o,
+  input  logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] rd_word_i,
+  output logic [DATA_W-1:0] rd_data_o,
+  output logic err_detected_o,
+  output logic err_corrected_o,
+  output logic err_uncorrectable_o
+);
+  logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] cw_corr;
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] syn;
+  logic tri;
+  taec_encoder #(.DATA_W(DATA_W)) u_we(.data_i(wr_data_i), .codeword_o(mem_word_o));
+  taec_decoder #(.DATA_W(DATA_W)) u_re(.codeword_i(rd_word_i), .data_o(rd_data_o), .corrected_codeword_o(cw_corr),
+    .syndrome_o(syn), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o), .triple_adjacent_corrected_o(tri));
+endmodule
+
+module sram_bch_wrapper #(
+  parameter int DATA_W = 8,
+  parameter int N = DATA_W + 6
+) (
+  input  logic [DATA_W-1:0] wr_data_i,
+  output logic [N-1:0]      mem_word_o,
+  input  logic [N-1:0]      rd_word_i,
+  output logic [DATA_W-1:0] rd_data_o,
+  output logic err_detected_o,
+  output logic err_corrected_o,
+  output logic err_uncorrectable_o
+);
+  logic [N-1:0] cw_corr;
+  logic [N-DATA_W-1:0] syn;
+  bch_encoder #(.N(N), .K(DATA_W)) u_we(.data_i(wr_data_i), .codeword_o(mem_word_o));
+  bch_decoder #(.N(N), .K(DATA_W)) u_re(.codeword_i(rd_word_i), .data_o(rd_data_o), .corrected_codeword_o(cw_corr),
+    .syndrome_o(syn), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule
+
+module sram_polar_wrapper #(
+  parameter int DATA_W = 8,
+  parameter int N = (DATA_W <= 8) ? 16 : ((DATA_W <= 16) ? 32 : 64)
+) (
+  input  logic [DATA_W-1:0] wr_data_i,
+  output logic [N-1:0]      mem_word_o,
+  input  logic [N-1:0]      rd_word_i,
+  output logic [DATA_W-1:0] rd_data_o,
+  output logic err_detected_o,
+  output logic err_corrected_o,
+  output logic err_uncorrectable_o
+);
+  logic [N-1:0] udbg, uh;
+  logic [N-1:0] cw_corr;
+  polar_encoder #(.N(N), .K(DATA_W)) u_we(.data_i(wr_data_i), .codeword_o(mem_word_o), .u_dbg_o(udbg));
+  polar_decoder #(.N(N), .K(DATA_W)) u_re(.codeword_i(rd_word_i), .data_o(rd_data_o), .corrected_codeword_o(cw_corr),
+    .u_hat_o(uh), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o), .err_uncorrectable_o(err_uncorrectable_o));
+endmodule
+
+// Concrete entry-point module names for code_db SRAM entries.
+module sram_secded_8  (input logic [7:0]  wr_data_i, output logic [12:0] mem_word_o, input logic [12:0] rd_word_i, output logic [7:0]  rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o);  sram_secded_wrapper #(.DATA_W(8))  u (.*); endmodule
+module sram_secded_16 (input logic [15:0] wr_data_i, output logic [21:0] mem_word_o, input logic [21:0] rd_word_i, output logic [15:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_secded_wrapper #(.DATA_W(16)) u (.*); endmodule
+module sram_secded_32 (input logic [31:0] wr_data_i, output logic [38:0] mem_word_o, input logic [38:0] rd_word_i, output logic [31:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_secded_wrapper #(.DATA_W(32)) u (.*); endmodule
+module sram_taec_8    (input logic [7:0]  wr_data_i, output logic [12:0] mem_word_o, input logic [12:0] rd_word_i, output logic [7:0]  rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o);  sram_taec_wrapper #(.DATA_W(8))    u (.*); endmodule
+module sram_taec_16   (input logic [15:0] wr_data_i, output logic [21:0] mem_word_o, input logic [21:0] rd_word_i, output logic [15:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_taec_wrapper #(.DATA_W(16))   u (.*); endmodule
+module sram_taec_32   (input logic [31:0] wr_data_i, output logic [38:0] mem_word_o, input logic [38:0] rd_word_i, output logic [31:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_taec_wrapper #(.DATA_W(32))   u (.*); endmodule
+module sram_bch_8     (input logic [7:0]  wr_data_i, output logic [13:0] mem_word_o, input logic [13:0] rd_word_i, output logic [7:0]  rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o);  sram_bch_wrapper #(.DATA_W(8), .N(14))  u (.*); endmodule
+module sram_bch_16    (input logic [15:0] wr_data_i, output logic [23:0] mem_word_o, input logic [23:0] rd_word_i, output logic [15:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_bch_wrapper #(.DATA_W(16), .N(24)) u (.*); endmodule
+module sram_bch_32    (input logic [31:0] wr_data_i, output logic [44:0] mem_word_o, input logic [44:0] rd_word_i, output logic [31:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_bch_wrapper #(.DATA_W(32), .N(45)) u (.*); endmodule
+module sram_polar_8   (input logic [7:0]  wr_data_i, output logic [15:0] mem_word_o, input logic [15:0] rd_word_i, output logic [7:0]  rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o);  sram_polar_wrapper #(.DATA_W(8), .N(16))  u (.*); endmodule
+module sram_polar_16  (input logic [15:0] wr_data_i, output logic [31:0] mem_word_o, input logic [31:0] rd_word_i, output logic [15:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_polar_wrapper #(.DATA_W(16), .N(32)) u (.*); endmodule
+module sram_polar_32  (input logic [31:0] wr_data_i, output logic [63:0] mem_word_o, input logic [63:0] rd_word_i, output logic [31:0] rd_data_o, output logic err_detected_o, err_corrected_o, err_uncorrectable_o); sram_polar_wrapper #(.DATA_W(32), .N(64)) u (.*); endmodule

--- a/asic/rtl/taec/taec_codec.sv
+++ b/asic/rtl/taec/taec_codec.sv
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+// File: taec_codec.sv
+// Purpose: TAEC-style decoder with single-error correction plus bounded
+//          triple-adjacent data-bit correction fallback.
+// Scheme: TAEC (modeled)
+// Assumptions: Triple adjacent means three consecutive data indices.
+//              Implementation uses Hamming syndrome pattern matching for
+//              3-adjacent signatures; non-adjacent triples remain uncorrectable.
+// Synthesizability: Yes (combinational bounded search).
+//------------------------------------------------------------------------------
+module taec_encoder #(
+  parameter int DATA_W = 64
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [DATA_W+ecc_pkg::hamming_parity_bits(DATA_W):0] codeword_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] parity_dbg;
+  secded_encoder #(.DATA_W(DATA_W)) u_enc (
+    .data_i(data_i), .codeword_o(codeword_o), .parity_dbg_o(parity_dbg)
+  );
+endmodule
+
+module taec_decoder #(
+  parameter int DATA_W = 64,
+  parameter int P_W    = ecc_pkg::hamming_parity_bits(DATA_W),
+  parameter int N_W    = DATA_W + P_W
+) (
+  input  logic [N_W:0]      codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [N_W:0]      corrected_codeword_o,
+  output logic [P_W-1:0]    syndrome_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic              triple_adjacent_corrected_o
+);
+  int i, cpos, d_idx;
+  logic [DATA_W-1:0] pre_data;
+  logic [N_W:0] secded_cw;
+  logic [P_W-1:0] syndrome;
+  logic overall_mm, det, cor, unc;
+  logic [N_W:0] mask;
+  logic [$clog2(N_W+2)-1:0] ep;
+  logic found_taec;
+  logic [N_W:0] taec_mask;
+
+  function automatic int data_idx_to_cpos0(input int unsigned data_idx);
+    int unsigned count;
+    int pos;
+    begin
+      count = 0;
+      for (pos = 1; pos <= N_W; pos++) begin
+        if (!ecc_pkg::is_pow2(pos)) begin
+          if (count == data_idx) return pos-1;
+          count++;
+        end
+      end
+      return 0;
+    end
+  endfunction
+
+  secded_decoder #(.DATA_W(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(pre_data), .corrected_codeword_o(secded_cw),
+    .syndrome_o(syndrome), .overall_mismatch_o(overall_mm), .err_detected_o(det),
+    .err_corrected_o(cor), .err_uncorrectable_o(unc), .correction_mask_o(mask), .error_pos_o(ep)
+  );
+
+  always_comb begin
+    found_taec = 1'b0;
+    taec_mask = '0;
+
+    // Triple-adjacent (odd-weight) appears with overall mismatch.
+    if ((syndrome != '0) && overall_mm) begin
+      for (i = 0; i < DATA_W-2; i++) begin
+        int p0, p1, p2;
+        logic [P_W-1:0] tri_sig;
+        p0 = data_idx_to_cpos0(i) + 1;
+        p1 = data_idx_to_cpos0(i+1) + 1;
+        p2 = data_idx_to_cpos0(i+2) + 1;
+        tri_sig = p0[P_W-1:0] ^ p1[P_W-1:0] ^ p2[P_W-1:0];
+        if (!found_taec && (tri_sig == syndrome)) begin
+          found_taec = 1'b1;
+          taec_mask[p0-1] = 1'b1;
+          taec_mask[p1-1] = 1'b1;
+          taec_mask[p2-1] = 1'b1;
+        end
+      end
+    end
+
+    // Keep SEC behavior priority for clear single-bit events.
+    if (cor) corrected_codeword_o = secded_cw;
+    else if (found_taec) corrected_codeword_o = codeword_i ^ taec_mask;
+    else corrected_codeword_o = secded_cw;
+
+    d_idx = 0;
+    data_o = '0;
+    for (cpos = 1; cpos <= N_W; cpos++) begin
+      if (!ecc_pkg::is_pow2(cpos)) begin
+        data_o[d_idx] = corrected_codeword_o[cpos-1];
+        d_idx++;
+      end
+    end
+
+    syndrome_o = syndrome;
+    err_detected_o = det;
+    triple_adjacent_corrected_o = (~cor) & found_taec;
+    err_corrected_o = cor | found_taec;
+    err_uncorrectable_o = det & ~(cor | found_taec);
+  end
+endmodule

--- a/asic/scripts/compile.sh
+++ b/asic/scripts/compile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TB=${1:-tb_secded}
+mkdir -p asic/out
+iverilog -g2012 -f asic/scripts/filelist.f asic/tb/${TB}.sv -o asic/out/${TB}.out

--- a/asic/scripts/filelist.f
+++ b/asic/scripts/filelist.f
@@ -1,0 +1,11 @@
++incdir+asic/include
+asic/include/ecc_pkg.sv
+asic/rtl/common/ecc_bitflip_corrector.sv
+asic/rtl/secded/secded_codec.sv
+asic/rtl/secdaec/secdaec_codec.sv
+asic/rtl/taec/taec_codec.sv
+asic/rtl/bch/bch_codec.sv
+asic/rtl/polar/polar_pkg.sv
+asic/rtl/polar/polar_codec.sv
+asic/rtl/sram/sram_wrappers.sv
+asic/rtl/common/ecc_entries.sv

--- a/asic/scripts/regress.sh
+++ b/asic/scripts/regress.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+for tb in tb_secded tb_secdaec tb_taec tb_bch tb_polar tb_sram_wrappers; do
+  echo "[RUN] $tb"
+  asic/scripts/run.sh "$tb"
+done

--- a/asic/scripts/run.sh
+++ b/asic/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TB=${1:-tb_secded}
+asic/scripts/compile.sh "$TB"
+vvp asic/out/${TB}.out

--- a/asic/tb/tb_bch.sv
+++ b/asic/tb/tb_bch.sv
@@ -1,0 +1,29 @@
+`timescale 1ns/1ps
+module tb_bch;
+  logic [50:0] d;
+  logic [62:0] cw, cwi, cwc;
+  logic [50:0] dout;
+  logic [11:0] syn;
+  logic det, cor, unc;
+
+  bch_encoder #(.N(63), .K(51)) enc(.data_i(d), .codeword_o(cw));
+  bch_decoder #(.N(63), .K(51)) dec(.codeword_i(cwi), .data_o(dout), .corrected_codeword_o(cwc), .syndrome_o(syn), .err_detected_o(det), .err_corrected_o(cor), .err_uncorrectable_o(unc));
+
+  initial begin
+    d = 51'h5a55_1234_0001; #1;
+    cwi = cw; #1;
+    if (dout !== d || det) $fatal(1, "bch no-error failed");
+
+    cwi = cw ^ (63'd1<<9); #1;
+    if (dout !== d || !cor) $fatal(1, "bch single-bit correction failed");
+
+    cwi = cw ^ (63'd1<<9) ^ (63'd1<<22); #1;
+    if (dout !== d || !cor) $fatal(1, "bch double-bit correction failed");
+
+    cwi = cw ^ (63'd1<<1) ^ (63'd1<<5) ^ (63'd1<<29); #1;
+    if (!unc) $fatal(1, "bch >2-bit should be uncorrectable");
+
+    $display("TB_BCH_PASS");
+    $finish;
+  end
+endmodule

--- a/asic/tb/tb_polar.sv
+++ b/asic/tb/tb_polar.sv
@@ -1,0 +1,29 @@
+`timescale 1ns/1ps
+module tb_polar;
+  logic [31:0] d;
+  logic [63:0] cw, cwi, cwc, udbg, uhat;
+  logic [31:0] dout;
+  logic det, cor, unc;
+  int i;
+
+  polar_encoder #(.N(64), .K(32)) enc(.data_i(d), .codeword_o(cw), .u_dbg_o(udbg));
+  polar_decoder #(.N(64), .K(32)) dec(.codeword_i(cwi), .data_o(dout), .corrected_codeword_o(cwc), .u_hat_o(uhat), .err_detected_o(det), .err_corrected_o(cor), .err_uncorrectable_o(unc));
+
+  initial begin
+    d = 32'h1234abcd; #1;
+    cwi = cw; #1;
+    if (dout !== d) $fatal(1, "polar no-error failed");
+
+    cwi = cw ^ (64'd1<<7); #1;
+    if (!det) $fatal(1, "polar single error detect failed");
+
+    for (i = 0; i < 20; i++) begin
+      d = $urandom;
+      #1; cwi = cw ^ (64'd1 << ($urandom%64)); #1;
+      if (unc) $fatal(1, "polar randomized bounded decode flagged uncorrectable unexpectedly");
+    end
+
+    $display("TB_POLAR_PASS");
+    $finish;
+  end
+endmodule

--- a/asic/tb/tb_secdaec.sv
+++ b/asic/tb/tb_secdaec.sv
@@ -1,0 +1,42 @@
+`timescale 1ns/1ps
+module tb_secdaec;
+  logic [63:0] d;
+  logic [71:0] cw, cwi, cwc;
+  logic [63:0] dout;
+  logic [6:0] syn;
+  logic det, cor, unc, adj;
+
+  secdaec_encoder #(.DATA_W(64)) enc(.data_i(d), .codeword_o(cw));
+  secdaec_decoder #(.DATA_W(64)) dec(.codeword_i(cwi), .data_o(dout), .corrected_codeword_o(cwc), .syndrome_o(syn), .err_detected_o(det), .err_corrected_o(cor), .err_uncorrectable_o(unc), .adjacent_double_corrected_o(adj));
+
+  function automatic int data_idx_to_cpos0(input int unsigned data_idx);
+    int count, pos;
+    begin
+      count = 0;
+      for (pos = 1; pos <= 71; pos++) begin
+        if ((pos & (pos-1)) != 0) begin
+          if (count == data_idx) return pos-1;
+          count++;
+        end
+      end
+      return 0;
+    end
+  endfunction
+
+  initial begin
+    d = 64'hfeed_face_cafe_beef; #1; cwi = cw; #1;
+    if (dout !== d) $fatal(1, "secdaec no-error failed");
+
+    cwi = cw;
+    cwi[data_idx_to_cpos0(10)] ^= 1'b1;
+    cwi[data_idx_to_cpos0(11)] ^= 1'b1;
+    #1;
+    if (dout !== d || !adj || !cor) $fatal(1, "secdaec adjacent double correction failed");
+
+    cwi = cw ^ (72'd1<<2) ^ (72'd1<<18); #1;
+    if (!unc) $fatal(1, "secdaec non-adj double should be uncorrectable");
+
+    $display("TB_SECDAEC_PASS");
+    $finish;
+  end
+endmodule

--- a/asic/tb/tb_secded.sv
+++ b/asic/tb/tb_secded.sv
@@ -1,0 +1,31 @@
+`timescale 1ns/1ps
+module tb_secded;
+  logic [63:0] d;
+  logic [71:0] cw, cwi, cwc;
+  logic [63:0] dout;
+  logic [6:0] syn;
+  logic om, det, cor, unc;
+  logic [71:0] mask;
+  logic [$clog2(73)-1:0] ep;
+  int i;
+
+  secded_encoder #(.DATA_W(64)) enc(.data_i(d), .codeword_o(cw), .parity_dbg_o());
+  secded_decoder #(.DATA_W(64)) dec(.codeword_i(cwi), .data_o(dout), .corrected_codeword_o(cwc), .syndrome_o(syn), .overall_mismatch_o(om), .err_detected_o(det), .err_corrected_o(cor), .err_uncorrectable_o(unc), .correction_mask_o(mask), .error_pos_o(ep));
+
+  initial begin
+    d = 64'h0123_4567_89ab_cdef;
+    #1; cwi = cw; #1;
+    if (dout !== d || det) $fatal(1, "secded no-error failed");
+
+    for (i = 0; i < 72; i++) begin
+      cwi = cw ^ (72'd1 << i); #1;
+      if (dout !== d || !cor) $fatal(1, "secded single-bit failed at %0d", i);
+    end
+
+    cwi = cw ^ (72'd1<<3) ^ (72'd1<<7); #1;
+    if (!unc) $fatal(1, "secded double-bit detect failed");
+
+    $display("TB_SEDDED_PASS");
+    $finish;
+  end
+endmodule

--- a/asic/tb/tb_sram_wrappers.sv
+++ b/asic/tb/tb_sram_wrappers.sv
@@ -1,0 +1,22 @@
+`timescale 1ns/1ps
+module tb_sram_wrappers;
+  logic [7:0] d8, q8; logic [12:0] m8, r8; logic de8, co8, un8;
+  logic [15:0] d16, q16; logic [31:0] m16p, r16p; logic dep, cop, unp;
+  logic [31:0] d32, q32; logic [44:0] m32b, r32b; logic deb, cob, unb;
+
+  sram_secded_8 u0(.wr_data_i(d8), .mem_word_o(m8), .rd_word_i(r8), .rd_data_o(q8), .err_detected_o(de8), .err_corrected_o(co8), .err_uncorrectable_o(un8));
+  sram_polar_16 u1(.wr_data_i(d16), .mem_word_o(m16p), .rd_word_i(r16p), .rd_data_o(q16), .err_detected_o(dep), .err_corrected_o(cop), .err_uncorrectable_o(unp));
+  sram_bch_32 u2(.wr_data_i(d32), .mem_word_o(m32b), .rd_word_i(r32b), .rd_data_o(q32), .err_detected_o(deb), .err_corrected_o(cob), .err_uncorrectable_o(unb));
+
+  initial begin
+    d8 = 8'hA5; #1; r8 = m8; #1; if (q8 !== d8) $fatal(1, "sram secded-8 no-error");
+    r8 = m8 ^ (13'd1<<4); #1; if (q8 !== d8 || !co8) $fatal(1, "sram secded-8 single error");
+
+    d16 = 16'hBEEF; #1; r16p = m16p; #1; if (q16 !== d16) $fatal(1, "sram polar-16 no-error");
+
+    d32 = 32'hdeadbeef; #1; r32b = m32b ^ (45'd1<<3) ^ (45'd1<<11); #1; if (q32 !== d32 || !cob) $fatal(1, "sram bch-32 2-bit correction");
+
+    $display("TB_SRAM_WRAPPERS_PASS");
+    $finish;
+  end
+endmodule

--- a/asic/tb/tb_taec.sv
+++ b/asic/tb/tb_taec.sv
@@ -1,0 +1,44 @@
+`timescale 1ns/1ps
+module tb_taec;
+  logic [63:0] d;
+  logic [71:0] cw, cwi, cwc;
+  logic [63:0] dout;
+  logic [6:0] syn;
+  logic det, cor, unc, tri;
+
+  taec_encoder #(.DATA_W(64)) enc(.data_i(d), .codeword_o(cw));
+  taec_decoder #(.DATA_W(64)) dec(.codeword_i(cwi), .data_o(dout), .corrected_codeword_o(cwc), .syndrome_o(syn), .err_detected_o(det), .err_corrected_o(cor), .err_uncorrectable_o(unc), .triple_adjacent_corrected_o(tri));
+
+  function automatic int data_idx_to_cpos0(input int unsigned data_idx);
+    int count, pos;
+    begin
+      count = 0;
+      for (pos = 1; pos <= 71; pos++) begin
+        if ((pos & (pos-1)) != 0) begin
+          if (count == data_idx) return pos-1;
+          count++;
+        end
+      end
+      return 0;
+    end
+  endfunction
+
+  initial begin
+    d = 64'h0bad_f00d_dead_beef; #1;
+    cwi = cw; #1;
+    if (dout !== d) $fatal(1, "taec no-error failed");
+
+    cwi = cw;
+    cwi[data_idx_to_cpos0(20)] ^= 1'b1;
+    cwi[data_idx_to_cpos0(21)] ^= 1'b1;
+    cwi[data_idx_to_cpos0(22)] ^= 1'b1;
+    #1;
+    if (dout !== d || !tri || !cor) $fatal(1, "taec triple-adj correction failed");
+
+    cwi = cw ^ (72'd1<<4) ^ (72'd1<<25) ^ (72'd1<<40); #1;
+    if (!unc) $fatal(1, "taec non-adj triple should be uncorrectable");
+
+    $display("TB_TAEC_PASS");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
### Motivation
- Provide a clean, synthesizable, debug-friendly SystemVerilog track that models the repository's ECC families in RTL for simulation and future synthesis/PPA work. 
- Support the full 19 code-db entries by mapping them to concrete RTL families and thin SRAM wrappers so existing project behavior is not altered.

### Description
- Added `asic/` tree with `asic/rtl/` (subdirs `common`, `secded`, `secdaec`, `taec`, `bch`, `polar`, `sram`), `asic/include/`, `asic/tb/`, `asic/docs/`, and `asic/scripts/` and populated with synthesizable, parameterized, heavily commented modules and TBs. 
- Implemented common infrastructure in `asic/include/ecc_pkg.sv` and `asic/rtl/common/ecc_bitflip_corrector.sv` plus top-level fixed/global aliases in `asic/rtl/common/ecc_entries.sv` (covers `sec-ded-64`, `sec-daec-64`, `taec-64`, `bch-63`, `polar-64-32`, `polar-64-48`, `polar-128-96`).
- Implemented family RTLs:
  - SEC-DED: `asic/rtl/secded/secded_codec.sv` (encoder/decoder with syndrome, correction mask, corrected codeword, extracted data outputs).
  - SEC-DAEC: `asic/rtl/secdaec/secdaec_codec.sv` (SE C-DED base + adjacent-double syndrome matching rescue).
  - TAEC: `asic/rtl/taec/taec_codec.sv` (SE C-DED base + bounded triple-adjacent matching; assumptions documented).
  - BCH: `asic/rtl/bch/bch_codec.sv` (systematic encoder, bounded t<=2 exhaustive candidate remainder check decoder with explicit limitations documented).
  - Polar: `asic/rtl/polar/polar_codec.sv` + `polar_pkg.sv` (Arikan transform encoder, frozen-mask helper, bounded hard-decision local-search decoder with explicit frozen-bit assumptions).
- Implemented SRAM wrappers and concrete `sram_*_{8,16,32}` entry modules in `asic/rtl/sram/sram_wrappers.sv` that thinly adapt family encoders/decoders to SRAM word widths and report ECC status.
- Added self-checking SystemVerilog testbenches under `asic/tb/` for each family and wrapper (`tb_secded`, `tb_secdaec`, `tb_taec`, `tb_bch`, `tb_polar`, `tb_sram_wrappers`), documentation `asic/docs/README_asic.md` and `asic/docs/MODULE_MAP.md`, and simple simulator scripts in `asic/scripts/` (`compile.sh`, `run.sh`, `regress.sh`, `filelist.f`).

### Testing
- Ran repository-required builds and tests: `make` completed successfully and `make test` passed (existing C++/Python test-suite remained green). 
- Ran Python test suite: `python3 -m pytest -q` completed with all tests passing (`219` tests passed in this environment).
- ASIC SV regression scripts were added: run them with `asic/scripts/regress.sh` which invokes `asic/scripts/compile.sh` then `vvp`; these require a SystemVerilog toolchain (the script uses `iverilog`). In this environment `asic/scripts/regress.sh` could not complete because `iverilog` is not installed (error: `iverilog: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01fb09d44832ea7f2410e193838c8)