### PR TITLE
Add synthesizable SRAM top wrappers integrating ECC encoders/decoders for SEC-DED/SEC-DAEC/TAEC/BCH/Polar

### DIFF
--- a/asic/README_ecc_wrappers.md
+++ b/asic/README_ecc_wrappers.md
@@ -1,0 +1,75 @@
+# ASIC Integrated ECC SRAM Wrappers
+
+This directory adds **synthesizable, top-level integrated SRAM wrappers** for fixed ECC entries:
+
+- `sec-ded-64`  -> `sram_secded_top`
+- `sec-daec-64` -> `sram_secdaec_top`
+- `taec-64`     -> `sram_taec_top`
+- `bch-63`      -> `sram_bch_top`
+- `polar-64-32` -> `sram_polar_64_32_top`
+- `polar-64-48` -> `sram_polar_64_48_top`
+- `polar-128-96`-> `sram_polar_128_96_top`
+
+## Module hierarchy pattern
+
+All top modules follow the same architecture:
+
+1. `*_encoder` maps `wdata` to ECC codeword.
+2. `sram_core` stores full codeword (`CODE_W`) at `addr`.
+3. `*_decoder` decodes/corrects read codeword.
+4. Outputs are gated with `valid` from the SRAM read pipeline.
+
+```
+write: wdata -> encoder -> sram_core.mem[addr]
+read : sram_core.mem[addr] -> decoder -> rdata + error flags
+```
+
+## Common interface
+
+Each top module exports:
+
+- `clk`, `rst_n`, `cs`, `we`, `addr`, `wdata`, `rdata`, `valid`
+- `err_detected`, `err_corrected`, `err_uncorrectable`
+- `double_error`, `adjacent_error`, `triple_adjacent_error`
+
+`valid` is asserted one cycle after `cs && !we`.
+
+## Files
+
+- `common/`
+  - `sram_core.sv`: shared synthesizable storage core.
+  - `ecc_types_pkg.sv`: optional shared enum/sizing helper package.
+- `secded/`
+  - `secded_encoder.sv`, `secded_decoder.sv`, `sram_secded_top.sv`
+- `secdaec/`
+  - `secdaec_encoder.sv`, `secdaec_decoder.sv`, `sram_secdaec_top.sv`
+- `taec/`
+  - `taec_encoder.sv`, `taec_decoder.sv`, `sram_taec_top.sv`
+- `bch/`
+  - `bch_encoder.sv`, `bch_decoder.sv`, `sram_bch_top.sv`
+- `polar/`
+  - `polar_encoder_64_32.sv`, `polar_decoder_64_32.sv`, `sram_polar_64_32_top.sv`
+  - `polar_encoder_64_48.sv`, `polar_decoder_64_48.sv`, `sram_polar_64_48_top.sv`
+  - `polar_encoder_128_96.sv`, `polar_decoder_128_96.sv`, `sram_polar_128_96_top.sv`
+
+## Synthesis/test usage notes
+
+- Include existing base codec files from `asic/rtl/*` together with new wrapper files.
+- The wrappers are pure RTL and avoid TB-only constructs.
+- `DEPTH` defaults to `2**ADDR_W`, override as needed for experiments.
+
+Example compile list concept:
+
+1. Base codec/package files (`asic/include/ecc_pkg.sv`, `asic/rtl/**`).
+2. New common files (`asic/common/**`).
+3. One selected ECC family wrapper set.
+
+## Assumptions and approximations
+
+- **SEC-DED**: standard single-error correction and double-error detection behavior.
+- **SEC-DAEC**: adjacent double-error correction follows the existing bounded adjacent search model.
+- **TAEC**: triple-adjacent correction follows the existing syndrome-pattern model.
+- **BCH(63,51)**: decoder uses existing bounded <=2-bit correction search (area-heavy but synthesizable).
+- **Polar** wrappers use existing bounded local-search decoder (not full SC/SCL decoder).
+
+These approximations are inherited from existing codec implementations and are preserved for interface and synthesis compatibility.

--- a/asic/bch/bch_decoder.sv
+++ b/asic/bch/bch_decoder.sv
@@ -1,0 +1,21 @@
+// BCH(63,51) fixed decoder wrapper.
+// NOTE: Underlying decoder is bounded (<=2 bit search) for synthesizability.
+module bch_63_decoder #(
+  parameter int DATA_W = 51,
+  parameter int ECC_W  = 12,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o
+);
+  logic [ECC_W-1:0] syndrome;
+  bch_decoder #(.N(CODE_W), .K(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .syndrome_o(syndrome), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o)
+  );
+endmodule

--- a/asic/bch/bch_encoder.sv
+++ b/asic/bch/bch_encoder.sv
@@ -1,0 +1,14 @@
+// BCH(63,51) fixed encoder wrapper.
+module bch_63_encoder #(
+  parameter int DATA_W = 51,
+  parameter int ECC_W  = 12,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  bch_encoder #(.N(CODE_W), .K(DATA_W)) u_enc (
+    .data_i(data_i),
+    .codeword_o(codeword_o)
+  );
+endmodule

--- a/asic/bch/sram_bch_top.sv
+++ b/asic/bch/sram_bch_top.sv
@@ -1,0 +1,48 @@
+// SRAM + BCH top wrapper (fixed entry: bch-63).
+// NOTE: Decoder behavior follows bounded-search BCH implementation.
+module sram_bch_top #(
+  parameter int DATA_W = 51,
+  parameter int ECC_W  = 12,
+  parameter int CODE_W = DATA_W + ECC_W,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc;
+
+  bch_63_encoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr),
+    .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+
+  bch_63_decoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/common/ecc_types_pkg.sv
+++ b/asic/common/ecc_types_pkg.sv
@@ -1,0 +1,25 @@
+//------------------------------------------------------------------------------
+// File: asic/common/ecc_types_pkg.sv
+// Purpose: Shared ECC/SRAM type and sizing helpers for top-level SRAM wrappers.
+// Notes  : Keeps wrapper interfaces and SRAM organization consistent.
+//------------------------------------------------------------------------------
+package ecc_types_pkg;
+  typedef enum logic [2:0] {
+    ECC_SECDED      = 3'd0,
+    ECC_SECDAEC     = 3'd1,
+    ECC_TAEC        = 3'd2,
+    ECC_BCH63       = 3'd3,
+    ECC_POLAR_64_32 = 3'd4,
+    ECC_POLAR_64_48 = 3'd5,
+    ECC_POLAR_128_96= 3'd6
+  } ecc_scheme_e;
+
+  function automatic int hamming_p_bits(input int data_w);
+    int p;
+    begin
+      p = 0;
+      while ((1 << p) < (data_w + p + 1)) p++;
+      return p;
+    end
+  endfunction
+endpackage

--- a/asic/common/sram_core.sv
+++ b/asic/common/sram_core.sv
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+// File: asic/common/sram_core.sv
+// Purpose: Reusable synthesizable single-port SRAM-style storage core for ECC.
+// Notes  : Read data is registered and returned 1 cycle after cs && !we.
+//------------------------------------------------------------------------------
+module sram_core #(
+  parameter int ADDR_W = 8,
+  parameter int CODE_W = 72,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [CODE_W-1:0] wcode,
+  output logic [CODE_W-1:0] rcode,
+  output logic              rvalid
+);
+  logic [CODE_W-1:0] mem [0:DEPTH-1];
+
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      rcode  <= '0;
+      rvalid <= 1'b0;
+    end else begin
+      rvalid <= 1'b0;
+
+      if (cs && we) begin
+        mem[addr] <= wcode;
+      end
+
+      if (cs && !we) begin
+        rcode  <= mem[addr];
+        rvalid <= 1'b1;
+      end
+    end
+  end
+endmodule

--- a/asic/polar/polar_decoder_128_96.sv
+++ b/asic/polar/polar_decoder_128_96.sv
@@ -1,0 +1,20 @@
+// Polar (128,96) fixed decoder wrapper.
+module polar_decoder_128_96 #(
+  parameter int DATA_W = 96,
+  parameter int CODE_W = 128,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o
+);
+  logic [CODE_W-1:0] u_hat;
+  polar_decoder #(.N(CODE_W), .K(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .u_hat_o(u_hat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o)
+  );
+endmodule

--- a/asic/polar/polar_decoder_64_32.sv
+++ b/asic/polar/polar_decoder_64_32.sv
@@ -1,0 +1,21 @@
+// Polar (64,32) fixed decoder wrapper.
+// NOTE: Underlying decoder is bounded local search, not full SC/SCL.
+module polar_decoder_64_32 #(
+  parameter int DATA_W = 32,
+  parameter int CODE_W = 64,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o
+);
+  logic [CODE_W-1:0] u_hat;
+  polar_decoder #(.N(CODE_W), .K(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .u_hat_o(u_hat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o)
+  );
+endmodule

--- a/asic/polar/polar_decoder_64_48.sv
+++ b/asic/polar/polar_decoder_64_48.sv
@@ -1,0 +1,20 @@
+// Polar (64,48) fixed decoder wrapper.
+module polar_decoder_64_48 #(
+  parameter int DATA_W = 48,
+  parameter int CODE_W = 64,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o
+);
+  logic [CODE_W-1:0] u_hat;
+  polar_decoder #(.N(CODE_W), .K(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .u_hat_o(u_hat), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o)
+  );
+endmodule

--- a/asic/polar/polar_encoder_128_96.sv
+++ b/asic/polar/polar_encoder_128_96.sv
@@ -1,0 +1,14 @@
+// Polar (128,96) fixed encoder wrapper.
+module polar_encoder_128_96 #(
+  parameter int DATA_W = 96,
+  parameter int CODE_W = 128,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  logic [CODE_W-1:0] u_dbg;
+  polar_encoder #(.N(CODE_W), .K(DATA_W)) u_enc (
+    .data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(u_dbg)
+  );
+endmodule

--- a/asic/polar/polar_encoder_64_32.sv
+++ b/asic/polar/polar_encoder_64_32.sv
@@ -1,0 +1,14 @@
+// Polar (64,32) fixed encoder wrapper.
+module polar_encoder_64_32 #(
+  parameter int DATA_W = 32,
+  parameter int CODE_W = 64,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  logic [CODE_W-1:0] u_dbg;
+  polar_encoder #(.N(CODE_W), .K(DATA_W)) u_enc (
+    .data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(u_dbg)
+  );
+endmodule

--- a/asic/polar/polar_encoder_64_48.sv
+++ b/asic/polar/polar_encoder_64_48.sv
@@ -1,0 +1,14 @@
+// Polar (64,48) fixed encoder wrapper.
+module polar_encoder_64_48 #(
+  parameter int DATA_W = 48,
+  parameter int CODE_W = 64,
+  parameter int ECC_W  = CODE_W - DATA_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  logic [CODE_W-1:0] u_dbg;
+  polar_encoder #(.N(CODE_W), .K(DATA_W)) u_enc (
+    .data_i(data_i), .codeword_o(codeword_o), .u_dbg_o(u_dbg)
+  );
+endmodule

--- a/asic/polar/sram_polar_128_96_top.sv
+++ b/asic/polar/sram_polar_128_96_top.sv
@@ -1,0 +1,44 @@
+// SRAM + Polar top wrapper (fixed entry: polar-128-96).
+module sram_polar_128_96_top #(
+  parameter int DATA_W = 96,
+  parameter int ECC_W  = 32,
+  parameter int CODE_W = 128,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc;
+
+  polar_encoder_128_96 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr), .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+  polar_decoder_128_96 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/polar/sram_polar_64_32_top.sv
+++ b/asic/polar/sram_polar_64_32_top.sv
@@ -1,0 +1,44 @@
+// SRAM + Polar top wrapper (fixed entry: polar-64-32).
+module sram_polar_64_32_top #(
+  parameter int DATA_W = 32,
+  parameter int ECC_W  = 32,
+  parameter int CODE_W = 64,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc;
+
+  polar_encoder_64_32 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr), .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+  polar_decoder_64_32 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/polar/sram_polar_64_48_top.sv
+++ b/asic/polar/sram_polar_64_48_top.sv
@@ -1,0 +1,44 @@
+// SRAM + Polar top wrapper (fixed entry: polar-64-48).
+module sram_polar_64_48_top #(
+  parameter int DATA_W = 48,
+  parameter int ECC_W  = 16,
+  parameter int CODE_W = 64,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc;
+
+  polar_encoder_64_48 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr), .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+  polar_decoder_64_48 #(.DATA_W(DATA_W), .CODE_W(CODE_W), .ECC_W(ECC_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/secdaec/secdaec_decoder.sv
+++ b/asic/secdaec/secdaec_decoder.sv
@@ -1,0 +1,22 @@
+// SEC-DAEC 64b fixed decoder wrapper.
+module secdaec_64_decoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic              adjacent_error_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] syndrome;
+
+  secdaec_decoder #(.DATA_W(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .syndrome_o(syndrome), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o), .adjacent_double_corrected_o(adjacent_error_o)
+  );
+endmodule

--- a/asic/secdaec/secdaec_encoder.sv
+++ b/asic/secdaec/secdaec_encoder.sv
@@ -1,0 +1,14 @@
+// SEC-DAEC 64b fixed encoder wrapper.
+module secdaec_64_encoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  secdaec_encoder #(.DATA_W(DATA_W)) u_enc (
+    .data_i(data_i),
+    .codeword_o(codeword_o)
+  );
+endmodule

--- a/asic/secdaec/sram_secdaec_top.sv
+++ b/asic/secdaec/sram_secdaec_top.sv
@@ -1,0 +1,48 @@
+// SRAM + SEC-DAEC top wrapper (fixed entry: sec-daec-64).
+module sram_secdaec_top #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc, dec_adj;
+
+  secdaec_64_encoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr),
+    .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+
+  secdaec_64_decoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc),
+    .adjacent_error_o(dec_adj)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc & ~dec_adj;
+  assign adjacent_error = valid & dec_adj;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/secded/secded_decoder.sv
+++ b/asic/secded/secded_decoder.sv
@@ -1,0 +1,34 @@
+// SEC-DED 64b fixed decoder wrapper.
+module secded_64_decoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic              double_error_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] syndrome;
+  logic overall_mismatch;
+  logic [CODE_W-1:0] correction_mask;
+  logic [$clog2(CODE_W+1)-1:0] error_pos;
+
+  secded_decoder #(.DATA_W(DATA_W)) u_dec (
+    .codeword_i(codeword_i),
+    .data_o(data_o),
+    .corrected_codeword_o(corrected_codeword_o),
+    .syndrome_o(syndrome),
+    .overall_mismatch_o(overall_mismatch),
+    .err_detected_o(err_detected_o),
+    .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o),
+    .correction_mask_o(correction_mask),
+    .error_pos_o(error_pos)
+  );
+
+  assign double_error_o = err_uncorrectable_o;
+endmodule

--- a/asic/secded/secded_encoder.sv
+++ b/asic/secded/secded_encoder.sv
@@ -1,0 +1,16 @@
+// SEC-DED 64b fixed encoder wrapper.
+module secded_64_encoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] parity_dbg;
+  secded_encoder #(.DATA_W(DATA_W)) u_enc (
+    .data_i(data_i),
+    .codeword_o(codeword_o),
+    .parity_dbg_o(parity_dbg)
+  );
+endmodule

--- a/asic/secded/sram_secded_top.sv
+++ b/asic/secded/sram_secded_top.sv
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+// SRAM + SEC-DED top wrapper (fixed entry: sec-ded-64).
+//------------------------------------------------------------------------------
+module sram_secded_top #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code;
+  logic [CODE_W-1:0] rd_code;
+  logic [CODE_W-1:0] corr_code;
+  logic dec_det, dec_cor, dec_unc, dec_dbl;
+
+  secded_64_encoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_enc (
+    .data_i(wdata),
+    .codeword_o(enc_code)
+  );
+
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr),
+    .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+
+  secded_64_decoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc),
+    .double_error_o(dec_dbl)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_dbl;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = 1'b0;
+endmodule

--- a/asic/taec/sram_taec_top.sv
+++ b/asic/taec/sram_taec_top.sv
@@ -1,0 +1,48 @@
+// SRAM + TAEC top wrapper (fixed entry: taec-64).
+module sram_taec_top #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W,
+  parameter int ADDR_W = 8,
+  parameter int DEPTH  = (1 << ADDR_W)
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic              cs,
+  input  logic              we,
+  input  logic [ADDR_W-1:0] addr,
+  input  logic [DATA_W-1:0] wdata,
+  output logic [DATA_W-1:0] rdata,
+  output logic              valid,
+  output logic              err_detected,
+  output logic              err_corrected,
+  output logic              err_uncorrectable,
+  output logic              double_error,
+  output logic              adjacent_error,
+  output logic              triple_adjacent_error
+);
+  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
+  logic dec_det, dec_cor, dec_unc, dec_tri;
+
+  taec_64_encoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_enc (
+    .data_i(wdata), .codeword_o(enc_code)
+  );
+
+  sram_core #(.ADDR_W(ADDR_W), .CODE_W(CODE_W), .DEPTH(DEPTH)) u_sram (
+    .clk(clk), .rst_n(rst_n), .cs(cs), .we(we), .addr(addr),
+    .wcode(enc_code), .rcode(rd_code), .rvalid(valid)
+  );
+
+  taec_64_decoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_dec (
+    .codeword_i(rd_code), .data_o(rdata), .corrected_codeword_o(corr_code),
+    .err_detected_o(dec_det), .err_corrected_o(dec_cor), .err_uncorrectable_o(dec_unc),
+    .triple_adjacent_error_o(dec_tri)
+  );
+
+  assign err_detected = valid & dec_det;
+  assign err_corrected = valid & dec_cor;
+  assign err_uncorrectable = valid & dec_unc;
+  assign double_error = valid & dec_unc & ~dec_tri;
+  assign adjacent_error = 1'b0;
+  assign triple_adjacent_error = valid & dec_tri;
+endmodule

--- a/asic/taec/taec_decoder.sv
+++ b/asic/taec/taec_decoder.sv
@@ -1,0 +1,22 @@
+// TAEC 64b fixed decoder wrapper.
+module taec_64_decoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [CODE_W-1:0] codeword_i,
+  output logic [DATA_W-1:0] data_o,
+  output logic [CODE_W-1:0] corrected_codeword_o,
+  output logic              err_detected_o,
+  output logic              err_corrected_o,
+  output logic              err_uncorrectable_o,
+  output logic              triple_adjacent_error_o
+);
+  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] syndrome;
+
+  taec_decoder #(.DATA_W(DATA_W)) u_dec (
+    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
+    .syndrome_o(syndrome), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
+    .err_uncorrectable_o(err_uncorrectable_o), .triple_adjacent_corrected_o(triple_adjacent_error_o)
+  );
+endmodule

--- a/asic/taec/taec_encoder.sv
+++ b/asic/taec/taec_encoder.sv
@@ -1,0 +1,14 @@
+// TAEC 64b fixed encoder wrapper.
+module taec_64_encoder #(
+  parameter int DATA_W = 64,
+  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
+  parameter int CODE_W = DATA_W + ECC_W
+) (
+  input  logic [DATA_W-1:0] data_i,
+  output logic [CODE_W-1:0] codeword_o
+);
+  taec_encoder #(.DATA_W(DATA_W)) u_enc (
+    .data_i(data_i),
+    .codeword_o(codeword_o)
+  );
+endmodule


### PR DESCRIPTION
### Motivation
- Provide a single, synthesizable SRAM-style top wrapper per ECC scheme so ASIC experiments can plug a uniform memory interface while swapping only the ECC logic.
- BCH and Polar previously existed as split encoder/decoder pieces and needed an integrated SRAM-facing top for clean synthesis and comparison.
- Keep SRAM organization and external interface identical across schemes to enable fair area/perf/reliability comparisons and easier downstream integration.

### Description
- Added a reusable single-port storage core `sram_core.sv` and a helper package `ecc_types_pkg.sv` under `asic/common/` to enforce consistent memory sizing and control (`cs/we`, registered read, `valid`).
- Implemented fixed encoder/decoder wrappers and integrated top modules for the requested ECC entries: `sram_secded_top`, `sram_secdaec_top`, `sram_taec_top`, `sram_bch_top`, `sram_polar_64_32_top`, `sram_polar_64_48_top`, and `sram_polar_128_96_top`, together with the corresponding per-code encoder/decoder wrappers under `asic/secded`, `asic/secdaec`, `asic/taec`, `asic/bch`, and `asic/polar`.
- Standardized the top-level SRAM interface across all wrappers to expose `clk`, `rst_n`, `cs`, `we`, `addr`, `wdata`, `rdata`, `valid`, and error flags `err_detected`, `err_corrected`, `err_uncorrectable`, plus advisory flags `double_error`, `adjacent_error`, and `triple_adjacent_error`.
- Added `asic/README_ecc_wrappers.md` documenting the module hierarchy, how to compile/synthesize, and the explicit approximations preserved from the underlying codec RTL (notably bounded BCH search and bounded Polar local-search decoder).

### Testing
- Ran `make` and the build completed successfully with the project's C++ tools and utilities compiled with no errors.
- Ran `make test` including smoke tests and the C++ unit harness; smoke tests passed and the unit test executables exercised ECC code paths successfully.
- Ran `python3 -m pytest -q` and the full Python test suite completed successfully (`219 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5803faa4c832ea467d81d21b046fb)