### PR TITLE
Self-contained Verilog-2001 SEC-DAEC encoder/decoder and top wrapper

### DIFF
--- a/asic/secdaec/secdaec_decoder.sv
+++ b/asic/secdaec/secdaec_decoder.sv
@@ -1,22 +1,136 @@
 // SEC-DAEC 64b fixed decoder wrapper.
+// Self-contained Verilog-2001 implementation (no package dependency).
 module secdaec_64_decoder #(
-  parameter int DATA_W = 64,
-  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
-  parameter int CODE_W = DATA_W + ECC_W
+  parameter DATA_W = 64,
+  parameter ECC_W  = 8,
+  parameter CODE_W = DATA_W + ECC_W
 ) (
-  input  logic [CODE_W-1:0] codeword_i,
-  output logic [DATA_W-1:0] data_o,
-  output logic [CODE_W-1:0] corrected_codeword_o,
-  output logic              err_detected_o,
-  output logic              err_corrected_o,
-  output logic              err_uncorrectable_o,
-  output logic              adjacent_error_o
+  input      [CODE_W-1:0] codeword_i,
+  output reg [DATA_W-1:0] data_o,
+  output reg [CODE_W-1:0] corrected_codeword_o,
+  output reg              err_detected_o,
+  output reg              err_corrected_o,
+  output reg              err_uncorrectable_o,
+  output reg              adjacent_error_o
 );
-  logic [ecc_pkg::hamming_parity_bits(DATA_W)-1:0] syndrome;
+  integer p;
+  integer cpos;
+  integer d_idx;
+  integer i;
+  integer p0;
+  integer p1;
+  integer err_pos;
 
-  secdaec_decoder #(.DATA_W(DATA_W)) u_dec (
-    .codeword_i(codeword_i), .data_o(data_o), .corrected_codeword_o(corrected_codeword_o),
-    .syndrome_o(syndrome), .err_detected_o(err_detected_o), .err_corrected_o(err_corrected_o),
-    .err_uncorrectable_o(err_uncorrectable_o), .adjacent_double_corrected_o(adjacent_error_o)
-  );
+  reg [ECC_W-2:0] syndrome;
+  reg overall_calc;
+  reg overall_mismatch;
+  reg [CODE_W-1:0] secded_corr;
+  reg [CODE_W-1:0] correction_mask;
+  reg found_adj;
+  reg [CODE_W-1:0] adj_mask;
+  reg [ECC_W-2:0] pair_sig;
+  reg [CODE_W-2:0] code_field;
+
+  function is_pow2;
+    input integer v;
+    begin
+      if (v <= 0) is_pow2 = 1'b0;
+      else is_pow2 = ((v & (v - 1)) == 0);
+    end
+  endfunction
+
+  function integer data_idx_to_cpos0;
+    input integer data_idx;
+    integer count;
+    integer pos;
+    begin
+      count = 0;
+      data_idx_to_cpos0 = 0;
+      for (pos = 1; pos <= CODE_W-1; pos = pos + 1) begin
+        if (!is_pow2(pos)) begin
+          if (count == data_idx) begin
+            data_idx_to_cpos0 = pos - 1;
+          end
+          count = count + 1;
+        end
+      end
+    end
+  endfunction
+
+  always @* begin
+    code_field = codeword_i[CODE_W-2:0];
+
+    // SEC-DED base decode.
+    syndrome = {ECC_W-1{1'b0}};
+    for (p = 0; p < ECC_W-1; p = p + 1) begin
+      reg sx;
+      sx = 1'b0;
+      for (cpos = 1; cpos <= CODE_W-1; cpos = cpos + 1) begin
+        if (cpos & (1 << p)) begin
+          sx = sx ^ codeword_i[cpos-1];
+        end
+      end
+      syndrome[p] = sx;
+    end
+
+    overall_calc = ^codeword_i[CODE_W-2:0];
+    overall_mismatch = (overall_calc != codeword_i[CODE_W-1]);
+    err_pos = syndrome;
+
+    correction_mask = {CODE_W{1'b0}};
+    err_detected_o = (syndrome != {ECC_W-1{1'b0}}) || overall_mismatch;
+    err_corrected_o = 1'b0;
+    err_uncorrectable_o = 1'b0;
+    adjacent_error_o = 1'b0;
+
+    if ((syndrome != {ECC_W-1{1'b0}}) && overall_mismatch) begin
+      if ((err_pos >= 1) && (err_pos <= CODE_W-1)) begin
+        correction_mask[err_pos-1] = 1'b1;
+        err_corrected_o = 1'b1;
+      end
+    end else if ((syndrome == {ECC_W-1{1'b0}}) && overall_mismatch) begin
+      correction_mask[CODE_W-1] = 1'b1;
+      err_corrected_o = 1'b1;
+    end else if ((syndrome != {ECC_W-1{1'b0}}) && !overall_mismatch) begin
+      err_uncorrectable_o = 1'b1;
+    end
+
+    secded_corr = codeword_i ^ correction_mask;
+
+    // DAEC adjacent-pair rescue for (syndrome!=0 && overall_mismatch==0).
+    found_adj = 1'b0;
+    adj_mask = {CODE_W{1'b0}};
+    if ((syndrome != {ECC_W-1{1'b0}}) && !overall_mismatch) begin
+      for (i = 0; i < DATA_W-1; i = i + 1) begin
+        p0 = data_idx_to_cpos0(i) + 1;
+        p1 = data_idx_to_cpos0(i+1) + 1;
+        pair_sig = p0[ECC_W-2:0] ^ p1[ECC_W-2:0];
+        if (!found_adj && (pair_sig == syndrome)) begin
+          found_adj = 1'b1;
+          adj_mask[p0-1] = 1'b1;
+          adj_mask[p1-1] = 1'b1;
+        end
+      end
+    end
+
+    if (found_adj) begin
+      corrected_codeword_o = codeword_i ^ adj_mask;
+      adjacent_error_o = 1'b1;
+      err_corrected_o = 1'b1;
+      err_uncorrectable_o = 1'b0;
+    end else begin
+      corrected_codeword_o = secded_corr;
+    end
+
+    d_idx = 0;
+    data_o = {DATA_W{1'b0}};
+    for (cpos = 1; cpos <= CODE_W-1; cpos = cpos + 1) begin
+      if (!is_pow2(cpos)) begin
+        if (d_idx < DATA_W) begin
+          data_o[d_idx] = corrected_codeword_o[cpos-1];
+          d_idx = d_idx + 1;
+        end
+      end
+    end
+  end
 endmodule

--- a/asic/secdaec/secdaec_encoder.sv
+++ b/asic/secdaec/secdaec_encoder.sv
@@ -1,14 +1,56 @@
 // SEC-DAEC 64b fixed encoder wrapper.
+// Self-contained Verilog-2001 implementation (no package dependency).
 module secdaec_64_encoder #(
-  parameter int DATA_W = 64,
-  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
-  parameter int CODE_W = DATA_W + ECC_W
+  parameter DATA_W = 64,
+  parameter ECC_W  = 8,
+  parameter CODE_W = DATA_W + ECC_W
 ) (
-  input  logic [DATA_W-1:0] data_i,
-  output logic [CODE_W-1:0] codeword_o
+  input      [DATA_W-1:0] data_i,
+  output reg [CODE_W-1:0] codeword_o
 );
-  secdaec_encoder #(.DATA_W(DATA_W)) u_enc (
-    .data_i(data_i),
-    .codeword_o(codeword_o)
-  );
+  integer d_idx;
+  integer p;
+  integer cpos;
+  reg [CODE_W-2:0] code_wo_overall;
+  reg overall;
+  reg px;
+
+  function is_pow2;
+    input integer v;
+    begin
+      if (v <= 0) is_pow2 = 1'b0;
+      else is_pow2 = ((v & (v - 1)) == 0);
+    end
+  endfunction
+
+  always @* begin
+    code_wo_overall = {CODE_W-1{1'b0}};
+    d_idx = 0;
+
+    // Fill non-parity positions (1-based indexing over CODE_W-1 field bits).
+    for (cpos = 1; cpos <= CODE_W-1; cpos = cpos + 1) begin
+      if (!is_pow2(cpos)) begin
+        if (d_idx < DATA_W) begin
+          code_wo_overall[cpos-1] = data_i[d_idx];
+          d_idx = d_idx + 1;
+        end
+      end
+    end
+
+    // Compute Hamming parity bits.
+    for (p = 0; p < ECC_W-1; p = p + 1) begin
+      px = 1'b0;
+      for (cpos = 1; cpos <= CODE_W-1; cpos = cpos + 1) begin
+        if (cpos & (1 << p)) begin
+          px = px ^ code_wo_overall[cpos-1];
+        end
+      end
+      if ((1 << p) <= (CODE_W-1)) begin
+        code_wo_overall[(1 << p)-1] = px;
+      end
+    end
+
+    overall = ^code_wo_overall;
+    codeword_o = {overall, code_wo_overall};
+  end
 endmodule

--- a/asic/secdaec/sram_secdaec_top.sv
+++ b/asic/secdaec/sram_secdaec_top.sv
@@ -1,28 +1,35 @@
 // SRAM + SEC-DAEC top wrapper (fixed entry: sec-daec-64).
+// Note: keep syntax Verilog-2001 compatible for synthesis flows that do not
+// enable full SystemVerilog package parsing at read time.
 module sram_secdaec_top #(
-  parameter int DATA_W = 64,
-  parameter int ECC_W  = ecc_pkg::hamming_parity_bits(DATA_W) + 1,
-  parameter int CODE_W = DATA_W + ECC_W,
-  parameter int ADDR_W = 8,
-  parameter int DEPTH  = (1 << ADDR_W)
+  parameter DATA_W = 64,
+  parameter ECC_W  = 8,
+  parameter CODE_W = DATA_W + ECC_W,
+  parameter ADDR_W = 8,
+  parameter DEPTH  = (1 << ADDR_W)
 ) (
-  input  logic              clk,
-  input  logic              rst_n,
-  input  logic              cs,
-  input  logic              we,
-  input  logic [ADDR_W-1:0] addr,
-  input  logic [DATA_W-1:0] wdata,
-  output logic [DATA_W-1:0] rdata,
-  output logic              valid,
-  output logic              err_detected,
-  output logic              err_corrected,
-  output logic              err_uncorrectable,
-  output logic              double_error,
-  output logic              adjacent_error,
-  output logic              triple_adjacent_error
+  input                   clk,
+  input                   rst_n,
+  input                   cs,
+  input                   we,
+  input      [ADDR_W-1:0] addr,
+  input      [DATA_W-1:0] wdata,
+  output     [DATA_W-1:0] rdata,
+  output                  valid,
+  output                  err_detected,
+  output                  err_corrected,
+  output                  err_uncorrectable,
+  output                  double_error,
+  output                  adjacent_error,
+  output                  triple_adjacent_error
 );
-  logic [CODE_W-1:0] enc_code, rd_code, corr_code;
-  logic dec_det, dec_cor, dec_unc, dec_adj;
+  wire [CODE_W-1:0] enc_code;
+  wire [CODE_W-1:0] rd_code;
+  wire [CODE_W-1:0] corr_code;
+  wire dec_det;
+  wire dec_cor;
+  wire dec_unc;
+  wire dec_adj;
 
   secdaec_64_encoder #(.DATA_W(DATA_W), .ECC_W(ECC_W), .CODE_W(CODE_W)) u_enc (
     .data_i(wdata), .codeword_o(enc_code)


### PR DESCRIPTION
### Motivation
- Remove dependency on SystemVerilog package helpers and provide a self-contained SEC-DAEC encoder/decoder implementation targeting Verilog-2001 compatible flows. 
- Provide a fixed 64-bit SEC-DAEC encoder/decoder pair with explicit parameter defaults and portability for synthesis flows that may not parse packages. 
- Make the SRAM + SEC-DAEC top wrapper compatible with the simplified modules and Verilog-2001-style port/net declarations.

### Description
- Replaced package-based `secdaec_encoder` and `secdaec_decoder` instantiations with self-contained implementations in `secdaec_64_encoder.sv` and `secdaec_64_decoder.sv` that compute Hamming parity bits and overall parity, and perform SEC-DED decode plus DAEC adjacent-pair rescue logic respectively. 
- Set parameters to concrete Verilog-style defaults (`DATA_W=64`, `ECC_W=8`, `CODE_W=DATA_W+ECC_W`) and removed `int` typed parameters and `ecc_pkg` calls. 
- Converted ports and internal signals to Verilog-2001-compatible declarations (`wire`/`reg` and simple vector types) and added helper functions `is_pow2` and `data_idx_to_cpos0` for index calculations. 
- Implemented syndrome calculation, overall parity check, correction mask generation, adjacent-pair detection and correction, and data extraction in the decoder; implemented data placement, parity bit computation and overall parity generation in the encoder. 
- Updated `sram_secdaec_top.sv` to use the new module interfaces and simplified output assignments (including a constant `triple_adjacent_error = 1'b0`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58ed79110832e87dfbc353ea82bac)