### PR TITLE
Add interactive, repository-backed ECC dashboard (Pareto explorer, leaderboard, scatter)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2,7 +2,9 @@ const state = {
   config: {},
   datasetCache: {},
   globalPoints: [],
-  selected: null
+  selected: null,
+  selectedCandidateIndex: 0,
+  numericFields: []
 };
 
 const summaryMetrics = [
@@ -29,9 +31,7 @@ const summaryMetrics = [
   {
     label: 'Latency',
     value: (row) =>
-      row?.latency_ns != null
-        ? `${formatNumber(row.latency_ns, 2)} ns`
-        : '—',
+      row?.latency_ns != null ? `${formatNumber(row.latency_ns, 2)} ns` : '—',
     detail: (row) =>
       row?.esii != null && row?.nesii != null
         ? `ESII ${formatNumber(row.esii, 3)} · NESII ${formatNumber(row.nesii, 1)}%`
@@ -65,6 +65,7 @@ async function init() {
     state.config = await fetchJSON('datasets.json');
     populateDatasetSelect();
     await loadGlobalPoints();
+    populateMetricControls();
 
     const firstKey = Object.keys(state.config)[0];
     if (firstKey) {
@@ -77,8 +78,21 @@ async function init() {
   }
 
   document.getElementById('dataset').addEventListener('change', async (event) => {
+    state.selectedCandidateIndex = 0;
     await loadDataset(event.target.value);
   });
+
+  document.getElementById('candidate').addEventListener('change', (event) => {
+    state.selectedCandidateIndex = Number(event.target.value) || 0;
+    renderCurrentCandidate();
+    updateParetoTable();
+  });
+
+  document.getElementById('leader-metric').addEventListener('change', updateLeaderboard);
+  document.getElementById('leader-dir').addEventListener('change', updateLeaderboard);
+
+  document.getElementById('x-metric').addEventListener('change', () => updateScatter());
+  document.getElementById('y-metric').addEventListener('change', () => updateScatter());
 
   document.getElementById('vdd-slider').addEventListener('input', (event) => {
     const sensitivity = state.datasetCache[state.selected]?.sensitivity;
@@ -102,12 +116,14 @@ function populateDatasetSelect() {
 async function loadGlobalPoints() {
   const entries = Object.entries(state.config);
   const points = [];
+
   for (const [key, info] of entries) {
     try {
       const rows = await d3.csv(info.pareto, d3.autoType);
       if (rows.length) {
-        const row = rows[0];
-        points.push({ key, label: info.label, row });
+        rows.forEach((row, index) => {
+          points.push({ key, label: info.label, row, index });
+        });
         state.datasetCache[key] = state.datasetCache[key] || {};
         state.datasetCache[key].pareto = rows;
       }
@@ -115,77 +131,171 @@ async function loadGlobalPoints() {
       console.warn(`Unable to load pareto data for ${key}`, error);
     }
   }
+
   state.globalPoints = points;
-  updateScatter();
+  inferNumericFields();
+}
+
+function inferNumericFields() {
+  const firstRow = state.globalPoints[0]?.row;
+  if (!firstRow) {
+    state.numericFields = [];
+    return;
+  }
+
+  const fields = Object.keys(firstRow).filter((field) =>
+    state.globalPoints.some((point) => Number.isFinite(Number(point.row[field])))
+  );
+
+  state.numericFields = fields;
+}
+
+function populateMetricControls() {
+  const fields = state.numericFields.length
+    ? state.numericFields
+    : ['carbon_kg', 'fit', 'latency_ns'];
+
+  populateSelect('leader-metric', fields, 'fit');
+  populateSelect('x-metric', fields, 'carbon_kg');
+  populateSelect('y-metric', fields, 'fit');
+}
+
+function populateSelect(id, fields, fallback) {
+  const select = document.getElementById(id);
+  if (!select) return;
+
+  select.innerHTML = '';
+  fields.forEach((field) => {
+    const option = document.createElement('option');
+    option.value = field;
+    option.textContent = humanizeField(field);
+    select.appendChild(option);
+  });
+
+  if (fields.includes(fallback)) {
+    select.value = fallback;
+  }
 }
 
 async function loadDataset(key) {
   state.selected = key;
   const info = state.config[key];
-  if (!info) {
-    return;
-  }
+  if (!info) return;
 
   const cache = state.datasetCache[key] || {};
   const tasks = [];
 
   if (!cache.pareto) {
     tasks.push(
-      d3
-        .csv(info.pareto, d3.autoType)
-        .then((rows) => {
-          cache.pareto = rows;
-        })
-        .catch((error) => {
-          console.error(`Failed to load pareto for ${key}`, error);
-          cache.pareto = [];
-        })
+      d3.csv(info.pareto, d3.autoType).then((rows) => {
+        cache.pareto = rows;
+      })
     );
   }
 
   if (!cache.archetypes) {
-    tasks.push(
-      fetchJSON(info.archetypes)
-        .then((json) => {
-          cache.archetypes = json;
-        })
-        .catch((error) => {
-          console.error(`Failed to load archetypes for ${key}`, error);
-          cache.archetypes = null;
-        })
-    );
+    tasks.push(fetchJSON(info.archetypes).then((json) => {
+      cache.archetypes = json;
+    }))
   }
 
   if (!cache.sensitivity) {
-    tasks.push(
-      fetchJSON(info.sensitivity)
-        .then((json) => {
-          cache.sensitivity = json;
-        })
-        .catch((error) => {
-          console.error(`Failed to load sensitivity for ${key}`, error);
-          cache.sensitivity = null;
-        })
-    );
+    tasks.push(fetchJSON(info.sensitivity).then((json) => {
+      cache.sensitivity = json;
+    }))
   }
 
   if (tasks.length) {
-    await Promise.all(tasks);
+    try {
+      await Promise.all(tasks);
+    } catch (error) {
+      console.error(`Failed to load one or more artifacts for ${key}`, error);
+    }
   }
 
   state.datasetCache[key] = cache;
 
-  const row = cache.pareto?.[0];
+  if (state.selectedCandidateIndex >= (cache.pareto?.length || 0)) {
+    state.selectedCandidateIndex = 0;
+  }
+
+  renderCurrentCandidate();
+  populateCandidateSelect(cache.pareto || []);
+  updateParetoTable();
+  updateFeasibleTable(cache.sensitivity);
+  updateVoltageControls(cache.sensitivity);
+  updateArchetypes(cache.archetypes);
+  updateLeaderboard();
+  updateScatter();
+}
+
+function renderCurrentCandidate() {
+  const row = state.datasetCache[state.selected]?.pareto?.[state.selectedCandidateIndex];
   if (row) {
     renderSummary(row);
   } else {
     showError('summary', 'No Pareto data found.');
   }
+}
 
-  updateFeasibleTable(cache.sensitivity);
-  updateVoltageControls(cache.sensitivity);
-  updateArchetypes(cache.archetypes);
-  updateScatter();
+function populateCandidateSelect(rows) {
+  const select = document.getElementById('candidate');
+  select.innerHTML = '';
+
+  if (!rows.length) {
+    const option = document.createElement('option');
+    option.value = '0';
+    option.textContent = 'No candidates';
+    select.appendChild(option);
+    select.disabled = true;
+    return;
+  }
+
+  select.disabled = false;
+  rows.forEach((row, idx) => {
+    const option = document.createElement('option');
+    option.value = String(idx);
+    option.textContent = `${row.code ?? 'candidate'} · FIT ${formatScientific(
+      row.fit
+    )} · Carbon ${formatNumber(row.carbon_kg, 2)}`;
+    select.appendChild(option);
+  });
+
+  select.value = String(state.selectedCandidateIndex);
+}
+
+function updateParetoTable() {
+  const tbody = document.querySelector('#pareto-table tbody');
+  tbody.innerHTML = '';
+
+  const rows = state.datasetCache[state.selected]?.pareto || [];
+  if (!rows.length) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 4;
+    td.textContent = 'No candidate rows found.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    return;
+  }
+
+  rows.forEach((row, idx) => {
+    const tr = document.createElement('tr');
+    if (idx === state.selectedCandidateIndex) tr.classList.add('selected');
+    tr.innerHTML = `
+      <td>${row.code ?? '—'}</td>
+      <td>${formatScientific(row.fit)}</td>
+      <td>${formatNumber(row.carbon_kg, 2)}</td>
+      <td>${formatNumber(row.latency_ns, 2)}</td>
+    `;
+    tr.addEventListener('click', () => {
+      state.selectedCandidateIndex = idx;
+      document.getElementById('candidate').value = String(idx);
+      renderCurrentCandidate();
+      updateParetoTable();
+    });
+    tbody.appendChild(tr);
+  });
 }
 
 function renderSummary(row) {
@@ -381,12 +491,59 @@ function updateArchetypes(archetypes) {
   });
 }
 
-function updateScatter() {
-  const svg = d3.select('#comparison-chart');
-  const node = svg.node();
-  if (!node) {
+function updateLeaderboard() {
+  const metric = document.getElementById('leader-metric').value;
+  const direction = document.getElementById('leader-dir').value;
+  const tbody = document.querySelector('#leaderboard tbody');
+  tbody.innerHTML = '';
+
+  const rows = state.globalPoints
+    .filter((point) => Number.isFinite(Number(point.row[metric])))
+    .sort((a, b) => {
+      const av = Number(a.row[metric]);
+      const bv = Number(b.row[metric]);
+      return direction === 'desc' ? bv - av : av - bv;
+    });
+
+  if (!rows.length) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 3;
+    td.textContent = 'No comparable rows found.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
     return;
   }
+
+  rows.forEach((point) => {
+    const tr = document.createElement('tr');
+    if (point.key === state.selected && point.index === state.selectedCandidateIndex) {
+      tr.classList.add('selected');
+    }
+
+    tr.innerHTML = `
+      <td>${point.label}</td>
+      <td>${point.row.code ?? '—'}</td>
+      <td>${formatMetricValue(point.row[metric])}</td>
+    `;
+
+    tr.addEventListener('click', async () => {
+      document.getElementById('dataset').value = point.key;
+      state.selectedCandidateIndex = point.index;
+      await loadDataset(point.key);
+      document.getElementById('candidate').value = String(point.index);
+    });
+
+    tbody.appendChild(tr);
+  });
+}
+
+function updateScatter() {
+  const metricX = document.getElementById('x-metric').value;
+  const metricY = document.getElementById('y-metric').value;
+  const svg = d3.select('#comparison-chart');
+  const node = svg.node();
+  if (!node) return;
 
   const width = node.getBoundingClientRect().width || 640;
   const height = node.getBoundingClientRect().height || 320;
@@ -395,40 +552,23 @@ function updateScatter() {
   svg.attr('viewBox', `0 0 ${width} ${height}`);
   svg.selectAll('*').remove();
 
-  const points = state.globalPoints.filter((point) => point.row);
-  if (!points.length) {
-    return;
-  }
+  const points = state.globalPoints.filter(
+    (point) => Number.isFinite(Number(point.row[metricX])) && Number.isFinite(Number(point.row[metricY]))
+  );
+  if (!points.length) return;
 
-  if (state.selected && state.datasetCache[state.selected]?.pareto?.[0]) {
-    const current = points.find((point) => point.key === state.selected);
-    if (current) {
-      current.row = state.datasetCache[state.selected].pareto[0];
-    }
-  }
-
-  const xValues = points.map((point) => point.row.carbon_kg).filter(isFinite);
-  const yValues = points.map((point) => point.row.fit).filter((value) => value > 0);
-
-  if (!xValues.length || !yValues.length) {
-    return;
-  }
+  const xValues = points.map((point) => Number(point.row[metricX]));
+  const yValues = points.map((point) => Number(point.row[metricY]));
 
   const xExtent = d3.extent(xValues);
   const yExtent = d3.extent(yValues);
+  if (!xExtent || !yExtent) return;
 
-  const xScale = d3
-    .scaleLinear()
-    .domain([Math.max(0, xExtent[0] * 0.9), xExtent[1] * 1.1])
-    .range([margin.left, width - margin.right]);
+  const xRange = paddedExtent(xExtent);
+  const yRange = paddedExtent(yExtent);
 
-  const yDomainMin = yExtent[0] === yExtent[1] ? yExtent[0] / 10 : yExtent[0];
-  const yDomainMax = yExtent[0] === yExtent[1] ? yExtent[1] * 10 : yExtent[1];
-
-  const yScale = d3
-    .scaleLog()
-    .domain([yDomainMin, yDomainMax])
-    .range([height - margin.bottom, margin.top]);
+  const xScale = d3.scaleLinear().domain(xRange).range([margin.left, width - margin.right]);
+  const yScale = d3.scaleLinear().domain(yRange).range([height - margin.bottom, margin.top]);
 
   const xAxis = (g) =>
     g
@@ -442,13 +582,13 @@ function updateScatter() {
           .attr('fill', 'currentColor')
           .attr('text-anchor', 'end')
           .attr('font-weight', '600')
-          .text('Carbon footprint (kg/GiB)')
+          .text(humanizeField(metricX))
       );
 
   const yAxis = (g) =>
     g
       .attr('transform', `translate(${margin.left}, 0)`)
-      .call(d3.axisLeft(yScale).ticks(6, '.1e'))
+      .call(d3.axisLeft(yScale).ticks(6))
       .call((axis) =>
         axis
           .append('text')
@@ -457,32 +597,44 @@ function updateScatter() {
           .attr('fill', 'currentColor')
           .attr('text-anchor', 'start')
           .attr('font-weight', '600')
-          .text('Failure rate (FIT)')
+          .text(humanizeField(metricY))
       );
 
   svg.append('g').attr('class', 'axis axis-x').call(xAxis);
   svg.append('g').attr('class', 'axis axis-y').call(yAxis);
 
-  const pointGroup = svg.append('g').attr('class', 'points');
-
-  const formatter = d3.format('.2e');
-
-  pointGroup
+  svg
+    .append('g')
     .selectAll('circle')
     .data(points)
     .join('circle')
-    .attr('cx', (d) => xScale(d.row.carbon_kg))
-    .attr('cy', (d) => yScale(Math.max(d.row.fit, yDomainMin)))
-    .attr('r', (d) => (d.key === state.selected ? 9 : 6))
-    .attr('fill', (d) => (d.key === state.selected ? 'var(--accent)' : 'rgba(148, 163, 184, 0.65)'))
+    .attr('cx', (d) => xScale(Number(d.row[metricX])))
+    .attr('cy', (d) => yScale(Number(d.row[metricY])))
+    .attr('r', (d) => (d.key === state.selected && d.index === state.selectedCandidateIndex ? 9 : 6))
+    .attr('fill', (d) =>
+      d.key === state.selected && d.index === state.selectedCandidateIndex
+        ? 'var(--accent)'
+        : 'rgba(148, 163, 184, 0.65)'
+    )
     .attr('stroke', 'rgba(255, 255, 255, 0.85)')
-    .attr('stroke-width', (d) => (d.key === state.selected ? 2.2 : 1.2))
+    .attr('stroke-width', (d) => (d.key === state.selected && d.index === state.selectedCandidateIndex ? 2.2 : 1.2))
+    .on('click', async (_, d) => {
+      document.getElementById('dataset').value = d.key;
+      state.selectedCandidateIndex = d.index;
+      await loadDataset(d.key);
+      document.getElementById('candidate').value = String(d.index);
+    })
     .append('title')
-    .text((d) =>
-      `${d.label}\nCarbon: ${formatNumber(d.row.carbon_kg, 2)} kg/GiB\nFIT: ${formatter(
-        d.row.fit
-      )}`
-    );
+    .text((d) => `${d.label}\n${humanizeField(metricX)}: ${formatMetricValue(d.row[metricX])}\n${humanizeField(metricY)}: ${formatMetricValue(d.row[metricY])}`);
+}
+
+function paddedExtent([lo, hi]) {
+  if (lo === hi) {
+    const delta = lo === 0 ? 1 : Math.abs(lo) * 0.1;
+    return [lo - delta, hi + delta];
+  }
+  const pad = (hi - lo) * 0.1;
+  return [lo - pad, hi + pad];
 }
 
 async function fetchJSON(url) {
@@ -497,9 +649,7 @@ async function fetchJSON(url) {
 
 function showError(containerId, message) {
   const container = document.getElementById(containerId);
-  if (!container) {
-    return;
-  }
+  if (!container) return;
   container.innerHTML = '';
   const error = document.createElement('p');
   error.textContent = message;
@@ -545,18 +695,32 @@ function formatRange(lower, upper) {
 }
 
 function formatBound(value) {
-  if (value == null) {
-    return '—';
-  }
-  if (value === 'inf' || value === Infinity) {
-    return '∞';
-  }
+  if (value == null) return '—';
+  if (value === 'inf' || value === Infinity) return '∞';
+
   const numeric = Number(value);
-  if (!Number.isFinite(numeric)) {
-    return String(value);
-  }
-  if (Math.abs(numeric) >= 1_000 || Math.abs(numeric) < 0.01) {
+  if (!Number.isFinite(numeric)) return String(value);
+
+  if (Math.abs(numeric) >= 1_000 || (Math.abs(numeric) > 0 && Math.abs(numeric) < 0.01)) {
     return numeric.toExponential(1);
   }
+
   return formatNumber(numeric, 2);
+}
+
+function humanizeField(field) {
+  return String(field)
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatMetricValue(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value == null ? '—' : String(value);
+  }
+  if (Math.abs(numeric) >= 1_000 || (Math.abs(numeric) > 0 && Math.abs(numeric) < 0.01)) {
+    return numeric.toExponential(2);
+  }
+  return formatNumber(numeric, 3);
 }

--- a/web/index.html
+++ b/web/index.html
@@ -17,15 +17,15 @@
       <div>
         <h1>SRAM ECC Design Explorer</h1>
         <p>
-          Explore example design trade-offs that ship with the
-          <code>Error-Code-Correction</code> repository. The dashboard presents
-          Pareto-optimal error correction configurations, archetype
-          classifications, and voltage sensitivity for representative SKUs.
+          Dynamic dashboard built from repository artifacts in
+          <code>reports/examples</code>. Explore Pareto points, archetypes,
+          voltage sensitivity, and cross-SKU metric rankings without any
+          external backend.
         </p>
       </div>
       <div class="cta">
         <a href="https://github.com/" target="_blank" rel="noreferrer">
-          Learn how to deploy on GitHub Pages
+          Deploy on GitHub Pages
         </a>
       </div>
     </header>
@@ -34,9 +34,8 @@
       <section class="panel">
         <h2>Choose a dataset</h2>
         <p>
-          Each dataset corresponds to one of the example benchmark reports in
-          <code>reports/examples</code>. Select a SKU to inspect its best-known
-          configuration at a 5&nbsp;s scrub interval.
+          Dataset entries come from <code>web/datasets.json</code> and point to
+          versioned artifacts already tracked by this repository.
         </p>
         <label class="dataset-select">
           <span>Dataset</span>
@@ -48,9 +47,34 @@
         <h2>Pareto summary</h2>
         <div id="summary" class="summary-grid" aria-live="polite"></div>
         <p class="footnote">
-          Values are reported per GiB and come directly from the
-          <code>pareto.csv</code> artifact for the selected configuration.
+          Metrics are read from the selected row in
+          <code>pareto.csv</code>.
         </p>
+      </section>
+
+      <section class="panel">
+        <h2>Pareto candidate explorer</h2>
+        <p>
+          Pick any candidate row from the selected dataset to refresh summary and
+          compare alternatives.
+        </p>
+        <div class="toolbar">
+          <label>
+            Candidate
+            <select id="candidate"></select>
+          </label>
+        </div>
+        <table id="pareto-table" class="data-table compact-table">
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">FIT</th>
+              <th scope="col">Carbon (kg)</th>
+              <th scope="col">Latency (ns)</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </section>
 
       <section class="panel">
@@ -81,20 +105,56 @@
       </section>
 
       <section class="panel">
-        <h2>Carbon vs. FIT comparison</h2>
+        <h2>Cross-SKU leaderboard</h2>
+        <div class="toolbar split">
+          <label>
+            Rank by
+            <select id="leader-metric"></select>
+          </label>
+          <label>
+            Direction
+            <select id="leader-dir">
+              <option value="asc">Lower is better</option>
+              <option value="desc">Higher is better</option>
+            </select>
+          </label>
+        </div>
+        <table id="leaderboard" class="data-table compact-table">
+          <thead>
+            <tr>
+              <th scope="col">Dataset</th>
+              <th scope="col">Code</th>
+              <th scope="col">Metric value</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <h2>Dynamic scatter view</h2>
         <p>
-          The scatter plot compares the shipped Pareto points for all example
-          SKUs. The selected dataset is highlighted.
+          Compare all datasets with selectable axes from available numeric
+          fields.
         </p>
-        <svg id="comparison-chart" role="img" aria-label="Scatter plot comparing carbon and FIT"></svg>
+        <div class="toolbar split">
+          <label>
+            X-axis
+            <select id="x-metric"></select>
+          </label>
+          <label>
+            Y-axis
+            <select id="y-metric"></select>
+          </label>
+        </div>
+        <svg id="comparison-chart" role="img" aria-label="Scatter plot comparing selected metrics"></svg>
       </section>
     </main>
 
     <footer class="page-footer">
       <p>
-        The dashboard is static and can be hosted as-is on GitHub Pages. To
-        update the data, regenerate the CSV/JSON artifacts and refresh the
-        <code>datasets.json</code> manifest.
+        The dashboard is static and can be hosted directly. Refresh
+        <code>datasets.json</code> to include additional report artifacts.
       </p>
     </footer>
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -99,13 +99,35 @@ main {
   font-weight: 600;
 }
 
-.dataset-select select {
+.dataset-select select,
+.toolbar select {
   padding: 0.6rem 0.75rem;
   border-radius: 12px;
   border: 1px solid rgba(148, 163, 184, 0.4);
   background: rgba(15, 23, 42, 0.6);
   color: var(--text-primary);
   font-size: 1rem;
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.toolbar.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.8rem;
+}
+
+.toolbar label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
 }
 
 .summary-grid {
@@ -181,12 +203,22 @@ main {
   font-size: 0.95rem;
 }
 
+.compact-table th,
+.compact-table td {
+  padding: 0.6rem 0.8rem;
+  font-size: 0.88rem;
+}
+
 .data-table tbody tr:last-child td {
   border-bottom: none;
 }
 
 .data-table tbody tr.selected {
   background: rgba(56, 189, 248, 0.12);
+}
+
+.data-table tbody tr {
+  cursor: pointer;
 }
 
 .archetype-grid {
@@ -230,6 +262,7 @@ main {
 
 #comparison-chart circle {
   transition: transform 0.2s ease;
+  cursor: pointer;
 }
 
 #comparison-chart circle:hover {


### PR DESCRIPTION
### Motivation
- Provide a dynamic, client-side dashboard that visualises existing `reports/examples` artifacts without requiring any external backend.
- Make it easy to explore alternative Pareto candidates, compare SKUs by arbitrary numeric metrics, and inspect voltage sensitivity and archetypes in a single static site.

### Description
- Expanded `web/index.html` to add a Pareto candidate explorer, a cross-SKU leaderboard with ranking controls, and a dynamic scatter view with selectable X/Y axes and candidate selector controls.
- Implemented new interactive behaviour in `web/app.js` to load all Pareto rows per dataset, infer numeric fields from CSV columns, populate metric controls, support candidate switching and clickable cross-navigation between tables and chart points, and preserve existing sensitivity/archetype rendering.
- Updated `web/styles.css` to add toolbar styles, compact-table styling, pointer/hover affordances, and layout adjustments that keep the original visual theme.
- Kept all data sources repository-local via `web/datasets.json` pointing at `reports/examples/...`, so no backend or schema changes were introduced.

### Testing
- Ran `make` which completed successfully.
- Ran `make test`, including compiled unit smoke tests and Python smoke checks, and the smoke tests passed.
- Ran the full Python test suite with `python3 -m pytest -q`, and the tests completed successfully (219 passed with 3 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a2c5c384832e8e0fa43928ea9846)