### PR TITLE
Add scenario-scoped OOD gating for ML advisory selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ python3 eccsim.py ml evaluate --help
 python3 eccsim.py ml report-card --help
 ```
 
+For narrow scenario datasets, train with scenario-scoped OOD gating to keep advisory mode meaningful while preserving explicit fallback:
+
+```bash
+python3 eccsim.py ml train \
+  --dataset <dataset_dir> --model-out <model_dir> \
+  --ood-feature-scope scenario
+```
+
 ---
 
 

--- a/docs/ml_design.md
+++ b/docs/ml_design.md
@@ -44,3 +44,7 @@
 - OOD is based on max absolute z-score against training feature statistics.
 - Confidence threshold and OOD threshold are stored in `thresholds.json`.
 - Any uncertainty path is explicit and traceable in CLI output via fallback reason.
+- OOD feature scope is configurable (`ood_feature_scope`):
+  - `full` (default): use all active numeric model features.
+  - `scenario`: use scenario-driving features only (`node`, `vdd`, `temp`, `capacity_gib`, `ci`, `bitcell_um2`, `scrub_s`) for OOD gating.
+    This avoids advisory suppression caused by code-specific metric shifts when scenario variation is narrow.

--- a/ecc_selector.py
+++ b/ecc_selector.py
@@ -848,6 +848,7 @@ def _selector_args_parser() -> argparse.ArgumentParser:
     parser.add_argument("--carbon-kg-max", type=float, default=None)
     parser.add_argument("--ml-confidence-min", type=float, default=None)
     parser.add_argument("--ml-ood-max", type=float, default=None)
+    parser.add_argument("--ml-ood-feature-scope", choices=["full", "scenario"], default=None)
     parser.add_argument(
         "--ml-policy",
         choices=["carbon_min", "fit_min", "energy_min", "utility_balanced"],
@@ -1025,6 +1026,7 @@ def _run_ml_advisory(args: argparse.Namespace) -> dict[str, object]:
         confidence_min_override=args.ml_confidence_min,
         ood_threshold_override=args.ml_ood_max,
         policy_override=args.ml_policy,
+        ood_feature_scope_override=args.ml_ood_feature_scope,
     )
     selected_policy = str(resolved_thresholds.get("ml_policy", "carbon_min"))
 
@@ -1050,6 +1052,7 @@ def _run_ml_advisory(args: argparse.Namespace) -> dict[str, object]:
             confidence_min_override=args.ml_confidence_min,
             ood_threshold_override=args.ml_ood_max,
             policy_override=args.ml_policy,
+            ood_feature_scope_override=args.ml_ood_feature_scope,
             strict_sanity=args.strict_sanity,
         )
 
@@ -1136,6 +1139,7 @@ def _run_ml_advisory(args: argparse.Namespace) -> dict[str, object]:
                 "confidence_score": float(ml_prediction.get("confidence", 0.0)) if ml_prediction else 0.0,
                 "confidence_threshold": float(resolved_thresholds.get("confidence_min", 0.6)),
                 "ood_method": str(resolved_thresholds.get("ood_method", "zscore")),
+                "ood_feature_scope": str(resolved_thresholds.get("ood_feature_scope", "full")),
                 "ood_score": float(ml_prediction.get("ood_score", 0.0)) if ml_prediction else 0.0,
                 "ood_threshold": float(resolved_thresholds.get("ood_threshold", 4.0)),
                 "in_distribution": bool(ml_prediction.get("in_distribution", False)) if ml_prediction else False,

--- a/eccsim.py
+++ b/eccsim.py
@@ -545,6 +545,7 @@ def main() -> None:
     ml_train.add_argument("--calibrate-confidence", choices=["none", "isotonic", "platt"], default="none")
     ml_train.add_argument("--confidence-target-metric", choices=["accuracy", "f1_macro"], default="accuracy")
     ml_train.add_argument("--ood-method", choices=["zscore", "mahalanobis", "iforest"], default="zscore")
+    ml_train.add_argument("--ood-feature-scope", choices=["full", "scenario"], default="full")
     ml_train.add_argument("--ood-quantile", type=_bounded_open_01, default=0.995)
     ml_train.add_argument("--conformal-alpha", type=_bounded_open_01, default=0.1)
 
@@ -749,6 +750,7 @@ def main() -> None:
                 calibrate_confidence=args.calibrate_confidence,
                 confidence_target_metric=args.confidence_target_metric,
                 ood_method=args.ood_method,
+                ood_feature_scope=args.ood_feature_scope,
                 ood_quantile=args.ood_quantile,
                 conformal_alpha=args.conformal_alpha,
             )
@@ -1495,6 +1497,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
 
 

--- a/ml/predict.py
+++ b/ml/predict.py
@@ -30,12 +30,14 @@ DEFAULT_THRESHOLDS: dict[str, float | str] = {
     "conformal_alpha": 0.1,
     "prediction_set_min_coverage": 0.0,
     "ml_policy": "carbon_min",
+    "ood_feature_scope": "full",
     # Internal helper for prediction-set construction.
     "conformal_prob_min": 0.5,
 }
 
 _ALLOWED_OOD_METHODS = {"zscore", "mahalanobis", "iforest"}
 _ALLOWED_POLICIES = {"carbon_min", "fit_min", "energy_min", "utility_balanced"}
+_ALLOWED_OOD_FEATURE_SCOPES = {"full", "scenario"}
 
 
 def load_model_bundle(model_dir: Path) -> dict:
@@ -67,6 +69,7 @@ def resolve_thresholds(
     confidence_min_override: float | None = None,
     ood_threshold_override: float | None = None,
     policy_override: str | None = None,
+    ood_feature_scope_override: str | None = None,
 ) -> dict[str, float | str]:
     """Resolve thresholds with backward-compatible defaults and overrides."""
 
@@ -100,6 +103,10 @@ def resolve_thresholds(
     if policy not in _ALLOWED_POLICIES:
         policy = "carbon_min"
     resolved["ml_policy"] = policy
+    ood_feature_scope = str(merged.get("ood_feature_scope", "full")).strip().lower()
+    if ood_feature_scope not in _ALLOWED_OOD_FEATURE_SCOPES:
+        ood_feature_scope = "full"
+    resolved["ood_feature_scope"] = ood_feature_scope
 
     if confidence_min_override is not None:
         resolved["confidence_min"] = float(confidence_min_override)
@@ -110,8 +117,28 @@ def resolve_thresholds(
         override_policy = str(policy_override).strip().lower()
         if override_policy in _ALLOWED_POLICIES:
             resolved["ml_policy"] = override_policy
+    if ood_feature_scope_override is not None:
+        override_scope = str(ood_feature_scope_override).strip().lower()
+        if override_scope in _ALLOWED_OOD_FEATURE_SCOPES:
+            resolved["ood_feature_scope"] = override_scope
 
     return resolved
+
+
+def _resolve_ood_numeric_features(numeric_features: list[str], scope: str) -> list[str]:
+    if scope == "scenario":
+        preferred = [
+            "node",
+            "vdd",
+            "temp",
+            "capacity_gib",
+            "ci",
+            "bitcell_um2",
+            "scrub_s",
+        ]
+        selected = [name for name in preferred if name in numeric_features]
+        return selected if selected else list(numeric_features)
+    return list(numeric_features)
 
 
 def _zscore_map(
@@ -195,6 +222,7 @@ def predict_with_model(
     confidence_min_override: float | None = None,
     ood_threshold_override: float | None = None,
     policy_override: str | None = None,
+    ood_feature_scope_override: str | None = None,
     strict_sanity: bool = False,
 ) -> dict[str, object]:
     """Predict recommended code and reliability/energy/carbon metrics."""
@@ -246,14 +274,17 @@ def predict_with_model(
         confidence_min_override=confidence_min_override,
         ood_threshold_override=ood_threshold_override,
         policy_override=policy_override,
+        ood_feature_scope_override=ood_feature_scope_override,
     )
 
     ood_method = str(thresholds["ood_method"])
+    ood_scope = str(thresholds.get("ood_feature_scope", "full"))
+    ood_numeric_features = _resolve_ood_numeric_features(numeric_features, ood_scope)
     ood_score, ood_detail = _ood_score(
         bundle,
         feature_row,
         method=ood_method,
-        numeric_features=numeric_features,
+        numeric_features=ood_numeric_features,
     )
     confidence_min = float(thresholds["confidence_min"])
     ood_threshold = float(thresholds["ood_threshold"])
@@ -281,6 +312,7 @@ def predict_with_model(
         },
         "ood": ood,
         "ood_method": ood_method,
+        "ood_feature_scope": ood_scope,
         "ood_score": ood_score,
         "ood_threshold": ood_threshold,
         # Legacy compatibility fields.

--- a/ml/train.py
+++ b/ml/train.py
@@ -226,6 +226,23 @@ def _calibrate_ood(
     return ood_payload, float(ood_threshold)
 
 
+def _resolve_ood_numeric_features(numeric_features: list[str], scope: str) -> list[str]:
+    scope_norm = str(scope).strip().lower()
+    if scope_norm == "scenario":
+        preferred = [
+            "node",
+            "vdd",
+            "temp",
+            "capacity_gib",
+            "ci",
+            "bitcell_um2",
+            "scrub_s",
+        ]
+        selected = [name for name in preferred if name in numeric_features]
+        return selected if selected else list(numeric_features)
+    return list(numeric_features)
+
+
 def train_models(
     dataset_dir: Path,
     model_out: Path,
@@ -237,12 +254,16 @@ def train_models(
     ood_method: str = "zscore",
     ood_quantile: float = 0.995,
     conformal_alpha: float = 0.1,
+    ood_feature_scope: str = "full",
 ) -> dict[str, Path]:
     """Train classifier/regressors and persist model artifacts."""
 
     dataset_dir = dataset_dir.resolve()
     model_out = model_out.resolve()
     model_out.mkdir(parents=True, exist_ok=True)
+    ood_feature_scope = str(ood_feature_scope).strip().lower()
+    if ood_feature_scope not in {"full", "scenario"}:
+        raise ValueError("ood_feature_scope must be one of: full, scenario")
 
     dataset_path = dataset_dir / "dataset.csv"
     if not dataset_path.is_file():
@@ -385,10 +406,11 @@ def train_models(
             "stds": stds,
         }
     }
+    ood_numeric_features = _resolve_ood_numeric_features(numeric_features, ood_feature_scope)
     ood_payload, ood_threshold = _calibrate_ood(
         bundle_stub=bundle_stub,
         X_train=X_train,
-        numeric_features=numeric_features,
+        numeric_features=ood_numeric_features,
         method=ood_method,
         quantile=float(ood_quantile),
         seed=seed,
@@ -402,6 +424,7 @@ def train_models(
         "conformal_alpha": float(conformal_alpha),
         "prediction_set_min_coverage": float(pred_set_coverage),
         "ml_policy": "carbon_min",
+        "ood_feature_scope": str(ood_feature_scope).strip().lower(),
         # Internal helper key used during prediction set construction.
         "conformal_prob_min": float(prob_floor),
     }

--- a/tests/python/test_ml_integration.py
+++ b/tests/python/test_ml_integration.py
@@ -83,6 +83,45 @@ def test_ml_train_to_predict_smoke():
         assert math.isfinite(float(pred["predictions"][key]))
 
 
+def test_ml_scenario_scoped_ood_enables_advisory_divergence():
+    model_dir = _prepare_model(
+        "scenario_scope_divergence",
+        seed=4,
+        ood_feature_scope="scenario",
+    )
+    cmd = [
+        sys.executable,
+        str(REPO / "ecc_selector.py"),
+        "--ml-model",
+        str(model_dir),
+        "--node",
+        "14",
+        "--vdd",
+        "0.8",
+        "--temp",
+        "75",
+        "--capacity-gib",
+        "8",
+        "--ci",
+        "0.55",
+        "--bitcell-um2",
+        "0.04",
+        "--scrub-s",
+        "5",
+        "--ml-policy",
+        "utility_balanced",
+        "--json",
+    ]
+    res = subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=REPO)
+    data = json.loads(res.stdout)
+
+    assert data["fallback_used"] is False
+    assert data["baseline_recommendation"] == "bch-63"
+    assert data["final_decision"] == "sec-ded-64"
+    assert data["final_decision"] != data["baseline_recommendation"]
+
+
+
 def test_selector_ood_fallback():
     model_dir = _prepare_model("ood", seed=1)
     cmd = [
@@ -205,6 +244,7 @@ def test_thresholds_schema_and_uncertainty_artifact():
         "confidence_min",
         "ood_max_abs_z",
         "ood_method",
+        "ood_feature_scope",
         "ood_threshold",
         "conformal_alpha",
         "prediction_set_min_coverage",


### PR DESCRIPTION
### Motivation
- ML advisory was being overly suppressed by OOD gating when datasets are narrow in scenario space, reducing ML usefulness while deterministic baseline remained authoritative. 
- Introduce a safe, backward-compatible operator control to make ML advisory meaningful for realistic, narrow-scenario deployments without changing default behavior.

### Description
- Add `ood_feature_scope` (default `full`) to ML thresholds and expose a new `scenario` option that restricts OOD scoring to scenario-driving numeric features (`node`, `vdd`, `temp`, `capacity_gib`, `ci`, `bitcell_um2`, `scrub_s`).
- Implement scope handling in `ml/predict.py` (`resolve_thresholds`, `_resolve_ood_numeric_features`, and use scoped features for `_ood_score`) and in `ml/train.py` (train-time calibration uses configured feature scope and persists `ood_feature_scope` into `thresholds.json`).
- Wire CLI flags: `eccsim.py ml train --ood-feature-scope {full,scenario}` and `ecc_selector.py --ml-ood-feature-scope {full,scenario}`, and surface the selected scope in ML debug output; persist scope into model artifacts for backward-compatible defaults.
- Add a focused integration test showing a reproducible scenario where ML advisory (with `ood_feature_scope=scenario`) surfaces a different, admissible recommendation than the deterministic baseline, and update docs/README with guidance.

### Testing
- Ran full build and test suite: `make`, `make test`, and `python3 -m pytest -q`, all tests passed (`227`+ tests; exit OK). 
- Exercised ML workflow end-to-end: built dataset and model with `python3 eccsim.py ml build-dataset --from reports/examples --out /tmp/ecc_ml_demo/dataset --seed 4 --label-policy utility_balanced` and trained with `python3 eccsim.py ml train --dataset /tmp/ecc_ml_demo/dataset --model-out /tmp/ecc_ml_demo/model --seed 4 --ood-feature-scope scenario` and then ran advisory selection: `python3 ecc_selector.py --ml-model /tmp/ecc_ml_demo/model --node 14 --vdd 0.8 --temp 75 --capacity-gib 8 --ci 0.55 --bitcell-um2 0.04 --scrub-s 5 --ml-policy utility_balanced --json`, which produced an admissible ML recommendation differing from the deterministic baseline (no fallback).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7edf6e558832ea459d47296bb5979)